### PR TITLE
Add tests for Electron main bootstrap and wake-word worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,8 @@ Track progress against `plan.md` here. Update the status markers (`[ ]` incomple
 - [ ] 14. Future Unity Integration Prep (Stretch)
 
 Keep this checklist accurate; it is the authoritative tracker for execution state.
+
+## Recent QA Activities
+
+- 2025-10-05 — Added integration tests for the main process bootstrap and Porcupine worker to raise coverage across wake word orchestration.
+- 2025-10-04 — Added Vitest coverage instrumentation and validated preload bridge ping wiring via renderer tests.

--- a/app/main/src/preload.ts
+++ b/app/main/src/preload.ts
@@ -10,6 +10,7 @@ export interface ConfigBridge {
 export interface PreloadApi {
   config: ConfigBridge;
   wakeWord: WakeWordBridge;
+  ping(): string;
 }
 
 export interface WakeWordBridge {
@@ -31,6 +32,7 @@ const api: PreloadApi = {
       };
     },
   },
+  ping: () => 'pong',
 };
 
 contextBridge.exposeInMainWorld('aiembodied', api);

--- a/app/main/tests/main.test.ts
+++ b/app/main/tests/main.test.ts
@@ -1,7 +1,405 @@
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('main process scaffolding', () => {
-  it('bootstraps test environment', () => {
-    expect(true).toBe(true);
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const dotenvConfigMock = vi.fn();
+
+vi.mock('dotenv', () => ({
+  default: { config: dotenvConfigMock },
+}));
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+const initializeLoggerMock = vi.fn(() => ({ logger: mockLogger }));
+vi.mock('../src/logging/logger.js', () => ({ initializeLogger: initializeLoggerMock }));
+
+const loadMock = vi.fn();
+const getConfigMock = vi.fn();
+const getRendererConfigMock = vi.fn();
+const getSecretMock = vi.fn();
+
+const ConfigManagerMock = vi.fn(() => ({
+  load: loadMock,
+  getConfig: getConfigMock,
+  getRendererConfig: getRendererConfigMock,
+  getSecret: getSecretMock,
+}));
+
+class ConfigValidationErrorMock extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigValidationError';
+  }
+}
+
+vi.mock('../src/config/config-manager.js', () => ({
+  ConfigManager: ConfigManagerMock,
+  ConfigValidationError: ConfigValidationErrorMock,
+}));
+
+vi.mock('../src/config/keytar-secret-store.js', () => ({
+  KeytarSecretStore: vi.fn(),
+}));
+
+vi.mock('../src/config/secret-store.js', () => ({
+  InMemorySecretStore: vi.fn(),
+}));
+
+class WakeWordServiceDouble extends EventEmitter {
+  start = vi.fn();
+  dispose = vi.fn().mockResolvedValue(undefined);
+  constructor(public readonly options: unknown) {
+    super();
+  }
+}
+
+const wakeWordServiceInstances: WakeWordServiceDouble[] = [];
+const createWakeWordServiceInstance = (options: unknown) => {
+  const instance = new WakeWordServiceDouble(options);
+  wakeWordServiceInstances.push(instance);
+  return instance;
+};
+const WakeWordServiceMock = vi.fn(createWakeWordServiceInstance);
+
+vi.mock('../src/wake-word/wake-word-service.js', () => ({
+  WakeWordService: WakeWordServiceMock,
+}));
+
+class CrashGuardDouble {
+  watch = vi.fn();
+  notifyAppQuitting = vi.fn();
+  constructor(public readonly options: unknown) {}
+}
+
+const crashGuardInstances: CrashGuardDouble[] = [];
+const createCrashGuardInstance = (options: unknown) => {
+  const instance = new CrashGuardDouble(options);
+  crashGuardInstances.push(instance);
+  return instance;
+};
+const CrashGuardMock = vi.fn(createCrashGuardInstance);
+
+vi.mock('../src/crash-guard.js', () => ({
+  CrashGuard: CrashGuardMock,
+}));
+
+interface MockBrowserWindow extends EventEmitter {
+  loadFile: ReturnType<typeof vi.fn>;
+  isDestroyed: ReturnType<typeof vi.fn>;
+  isMinimized: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  focus: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  webContents: EventEmitter & { send: ReturnType<typeof vi.fn> };
+}
+
+const createdWindows: MockBrowserWindow[] = [];
+let getAllWindowsResult: MockBrowserWindow[] = createdWindows;
+
+const BrowserWindowMock = vi.fn(() => {
+  const windowEmitter = new EventEmitter() as MockBrowserWindow;
+  const webContents = new EventEmitter() as MockBrowserWindow['webContents'];
+  webContents.send = vi.fn();
+  windowEmitter.webContents = webContents;
+  windowEmitter.loadFile = vi.fn(() => Promise.resolve());
+  windowEmitter.isDestroyed = vi.fn(() => false);
+  windowEmitter.isMinimized = vi.fn(() => false);
+  windowEmitter.restore = vi.fn();
+  windowEmitter.focus = vi.fn();
+  windowEmitter.destroy = vi.fn();
+  createdWindows.push(windowEmitter);
+  return windowEmitter;
+});
+
+BrowserWindowMock.getAllWindows = vi.fn(() => getAllWindowsResult);
+
+const dialogMock = { showErrorBox: vi.fn() };
+const ipcMainMock = {
+  handle: vi.fn(),
+};
+
+const appEmitter = Object.assign(new EventEmitter(), {
+  whenReady: vi.fn<[], Promise<void>>(),
+  requestSingleInstanceLock: vi.fn(() => true),
+  quit: vi.fn(),
+});
+
+vi.mock('electron', () => ({
+  app: appEmitter,
+  BrowserWindow: BrowserWindowMock,
+  dialog: dialogMock,
+  ipcMain: ipcMainMock,
+}));
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+async function waitForExpect(assertion: () => void, timeoutMs = 250): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() <= deadline) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  throw lastError ?? new Error('waitForExpect timed out');
+}
+
+describe('main process bootstrap', () => {
+  let whenReadyDeferred: Deferred<void>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.NODE_ENV = 'test';
+
+    dotenvConfigMock.mockClear();
+    initializeLoggerMock.mockClear();
+
+    loadMock.mockReset();
+    getConfigMock.mockReset();
+    getRendererConfigMock.mockReset();
+    getSecretMock.mockReset();
+    ConfigManagerMock.mockClear();
+
+    WakeWordServiceMock.mockReset();
+    WakeWordServiceMock.mockImplementation(createWakeWordServiceInstance);
+    wakeWordServiceInstances.length = 0;
+
+    CrashGuardMock.mockReset();
+    CrashGuardMock.mockImplementation(createCrashGuardInstance);
+    crashGuardInstances.length = 0;
+
+    createdWindows.length = 0;
+    getAllWindowsResult = createdWindows;
+    BrowserWindowMock.mockClear();
+    (BrowserWindowMock.getAllWindows as ReturnType<typeof vi.fn>).mockClear();
+
+    dialogMock.showErrorBox.mockReset();
+    ipcMainMock.handle.mockReset();
+
+    appEmitter.removeAllListeners();
+    appEmitter.whenReady.mockReset();
+    appEmitter.requestSingleInstanceLock.mockReset();
+    appEmitter.quit.mockReset();
+
+    whenReadyDeferred = createDeferred<void>();
+    appEmitter.whenReady.mockImplementation(() => whenReadyDeferred.promise);
+    appEmitter.requestSingleInstanceLock.mockReturnValue(true);
+
+    mockLogger.info.mockReset();
+    mockLogger.warn.mockReset();
+    mockLogger.error.mockReset();
+    mockLogger.debug.mockReset();
+  });
+
+  it('quits when another instance already holds the lock', async () => {
+    appEmitter.requestSingleInstanceLock.mockReturnValue(false);
+
+    const config = {
+      realtimeApiKey: 'rt-key',
+      featureFlags: {},
+      wakeWord: {
+        accessKey: 'access',
+        keywordPath: 'keyword.ppn',
+        keywordLabel: 'Porcupine',
+        sensitivity: 0.6,
+        minConfidence: 0.4,
+        cooldownMs: 750,
+      },
+    } as const;
+
+    loadMock.mockResolvedValue(config);
+    getConfigMock.mockReturnValue(config);
+
+    await import('../src/main.js');
+
+    expect(appEmitter.requestSingleInstanceLock).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Another instance of aiembodied is already running. Quitting.',
+    );
+    expect(appEmitter.quit).toHaveBeenCalledTimes(1);
+
+    whenReadyDeferred.resolve();
+    await whenReadyDeferred.promise;
+    await flushPromises();
+  });
+
+  it('initializes wake word service, ipc handlers, and window lifecycle on ready', async () => {
+    const config = {
+      realtimeApiKey: 'rt-key',
+      audioInputDeviceId: undefined,
+      audioOutputDeviceId: undefined,
+      featureFlags: {},
+      wakeWord: {
+        accessKey: 'access',
+        keywordPath: 'keyword.ppn',
+        keywordLabel: 'Porcupine',
+        sensitivity: 0.5,
+        minConfidence: 0.6,
+        cooldownMs: 900,
+        deviceIndex: 1,
+        modelPath: '/path/to/model',
+      },
+    } as const;
+
+    loadMock.mockResolvedValue(config);
+    getConfigMock.mockReturnValue(config);
+    getRendererConfigMock.mockReturnValue({ hasRealtimeApiKey: true });
+
+    const serviceReady = createDeferred<void>();
+    WakeWordServiceMock.mockImplementation((options: unknown) => {
+      const instance = createWakeWordServiceInstance(options);
+      serviceReady.resolve();
+      return instance;
+    });
+
+    await import('../src/main.js');
+
+    whenReadyDeferred.resolve();
+    await whenReadyDeferred.promise;
+    await flushPromises();
+    await serviceReady.promise;
+
+    expect(loadMock).toHaveBeenCalledTimes(1);
+    expect(WakeWordServiceMock).toHaveBeenCalledTimes(1);
+    expect(WakeWordServiceMock.mock.calls[0][0]).toMatchObject({
+      logger: mockLogger,
+      cooldownMs: config.wakeWord.cooldownMs,
+      minConfidence: config.wakeWord.minConfidence,
+    });
+
+    const wakeWordService = wakeWordServiceInstances[0];
+    expect(wakeWordService.start).toHaveBeenCalledWith({
+      accessKey: config.wakeWord.accessKey,
+      keywordPath: config.wakeWord.keywordPath,
+      keywordLabel: config.wakeWord.keywordLabel,
+      sensitivity: config.wakeWord.sensitivity,
+      modelPath: config.wakeWord.modelPath,
+      deviceIndex: config.wakeWord.deviceIndex,
+    });
+
+    expect(BrowserWindowMock).toHaveBeenCalledTimes(1);
+    const mainWindow = createdWindows[0];
+    expect(mainWindow.loadFile).toHaveBeenCalledWith(
+      expect.stringContaining('renderer/dist/index.html'),
+    );
+
+    expect(crashGuardInstances).toHaveLength(1);
+    expect(crashGuardInstances[0].watch).toHaveBeenCalledWith(mainWindow);
+
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(2);
+    const [configChannel, configHandler] = ipcMainMock.handle.mock.calls[0];
+    expect(configChannel).toBe('config:get');
+    expect(configHandler()).toEqual({ hasRealtimeApiKey: true });
+
+    const [secretChannel, secretHandler] = ipcMainMock.handle.mock.calls[1];
+    expect(secretChannel).toBe('config:get-secret');
+    getSecretMock.mockResolvedValueOnce('secret');
+    await expect(secretHandler({}, 'realtimeApiKey')).resolves.toBe('secret');
+    expect(getSecretMock).toHaveBeenCalledWith('realtimeApiKey');
+
+    const wakePayload = { keywordLabel: 'Porcupine', confidence: 0.92, timestamp: Date.now() };
+    wakeWordService.emit('wake', wakePayload);
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('wake-word:event', wakePayload);
+
+    const wakeError = new Error('worker failed');
+    wakeWordService.emit('error', wakeError);
+    expect(mockLogger.error).toHaveBeenCalledWith('Wake word service error', {
+      message: wakeError.message,
+      stack: wakeError.stack,
+    });
+
+    wakeWordService.emit('ready', { keywordLabel: 'Porcupine', frameLength: 512, sampleRate: 16000 });
+    expect(mockLogger.info).toHaveBeenCalledWith('Wake word service ready', {
+      keywordLabel: 'Porcupine',
+      frameLength: 512,
+      sampleRate: 16000,
+    });
+
+    mainWindow.emit('ready-to-show');
+    expect(mockLogger.info).toHaveBeenCalledWith('Main window ready to show.');
+
+    mainWindow.emit('closed');
+    expect(createdWindows[0].isDestroyed()).toBe(false);
+
+    appEmitter.emit('second-instance');
+    expect(mockLogger.warn).toHaveBeenLastCalledWith(
+      'Main window missing on second-instance event. Relaunching.',
+    );
+    expect(BrowserWindowMock).toHaveBeenCalledTimes(2);
+
+    const replacementWindow = createdWindows[1];
+    replacementWindow.isDestroyed.mockReturnValue(false);
+    replacementWindow.isMinimized.mockReturnValue(true);
+    appEmitter.emit('second-instance');
+    expect(replacementWindow.restore).toHaveBeenCalledTimes(1);
+    expect(replacementWindow.focus).toHaveBeenCalledTimes(1);
+
+    replacementWindow.isMinimized.mockReturnValue(false);
+    appEmitter.emit('second-instance');
+    expect(replacementWindow.restore).toHaveBeenCalledTimes(1);
+    expect(replacementWindow.focus).toHaveBeenCalledTimes(2);
+
+    getAllWindowsResult = [];
+    appEmitter.emit('activate');
+    expect(BrowserWindowMock).toHaveBeenCalledTimes(3);
+
+    appEmitter.emit('before-quit');
+    expect(crashGuardInstances[0].notifyAppQuitting).toHaveBeenCalledTimes(1);
+    expect(wakeWordService.dispose).toHaveBeenCalledTimes(1);
+    await expect(wakeWordService.dispose.mock.results[0].value).resolves.toBeUndefined();
+
+    appEmitter.emit('window-all-closed');
+    expect(appEmitter.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces configuration validation failures to the user', async () => {
+    const { ConfigValidationError } = await import('../src/config/config-manager.js');
+    const error = new ConfigValidationError('invalid config');
+    loadMock.mockRejectedValue(error);
+
+    await import('../src/main.js');
+
+    whenReadyDeferred.resolve();
+    await flushPromises();
+
+    await waitForExpect(() => {
+      expect(mockLogger.error).toHaveBeenCalledWith('Configuration validation failed', {
+        message: error.message,
+      });
+    });
+    await waitForExpect(() => {
+      expect(dialogMock.showErrorBox).toHaveBeenCalledWith('Configuration Error', error.message);
+    });
+    await waitForExpect(() => {
+      expect(appEmitter.quit).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/app/main/tests/porcupine-worker.test.ts
+++ b/app/main/tests/porcupine-worker.test.ts
@@ -1,0 +1,189 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WakeWordWorkerMessage } from '../src/wake-word/types.js';
+
+interface ParentPortMock extends EventEmitter {
+  postMessage: ReturnType<typeof vi.fn>;
+}
+
+const workerConfig = {
+  accessKey: 'access-key',
+  keywordPath: '/tmp/keyword.ppn',
+  keywordLabel: 'Porcupine',
+  sensitivity: 0.7,
+  modelPath: '/tmp/model.pv',
+  deviceIndex: 2,
+};
+
+const parentPortEmitter = new EventEmitter() as ParentPortMock;
+parentPortEmitter.postMessage = vi.fn();
+
+vi.mock('node:worker_threads', () => ({
+  parentPort: parentPortEmitter,
+  workerData: workerConfig,
+}));
+
+let porcupineProcessQueue: number[] = [];
+
+class PorcupineFake {
+  frameLength = 512;
+  sampleRate = 16000;
+  readonly process = vi.fn(() => (porcupineProcessQueue.length ? porcupineProcessQueue.shift()! : -1));
+  readonly release = vi.fn();
+  constructor(
+    public readonly accessKey: string,
+    public readonly keywords: string[],
+    public readonly sensitivities: number[],
+    public readonly modelPath?: string,
+  ) {}
+}
+
+const porcupineInstances: PorcupineFake[] = [];
+const PorcupineCtor = vi.fn(
+  (accessKey: string, keywords: string[], sensitivities: number[], modelPath?: string) => {
+    const instance = new PorcupineFake(accessKey, keywords, sensitivities, modelPath);
+    porcupineInstances.push(instance);
+    return instance;
+  },
+);
+
+vi.mock('@picovoice/porcupine-node', () => ({
+  Porcupine: PorcupineCtor,
+}));
+
+let recorderReadQueue: Array<() => Promise<Int16Array>> = [];
+
+class PvRecorderFake {
+  readonly start = vi.fn();
+  readonly stop = vi.fn();
+  readonly release = vi.fn();
+  constructor(
+    public readonly frameLength: number,
+    public readonly deviceIndex: number,
+    public readonly bufferSize: number,
+  ) {}
+
+  read(): Promise<Int16Array> {
+    if (recorderReadQueue.length) {
+      return recorderReadQueue.shift()!();
+    }
+
+    return Promise.resolve(new Int16Array(this.frameLength));
+  }
+}
+
+const recorderInstances: PvRecorderFake[] = [];
+const PvRecorderCtor = vi.fn((frameLength: number, deviceIndex: number, bufferSize: number) => {
+  const instance = new PvRecorderFake(frameLength, deviceIndex, bufferSize);
+  recorderInstances.push(instance);
+  return instance;
+});
+
+vi.mock('@picovoice/pvrecorder-node', () => ({
+  PvRecorder: PvRecorderCtor,
+}));
+
+const flushAsync = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+async function waitForMessage(predicate: (message: WakeWordWorkerMessage) => boolean) {
+  const timeoutAt = Date.now() + 500;
+  while (Date.now() < timeoutAt) {
+    const message = parentPortEmitter.postMessage.mock.calls
+      .map(([payload]) => payload as WakeWordWorkerMessage)
+      .find(predicate);
+    if (message) {
+      return message;
+    }
+    await flushAsync();
+  }
+
+  throw new Error('Timed out waiting for worker message');
+}
+
+describe('porcupine worker', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    porcupineProcessQueue = [];
+    recorderReadQueue = [];
+
+    parentPortEmitter.removeAllListeners();
+    parentPortEmitter.postMessage.mockReset();
+
+    porcupineInstances.length = 0;
+    PorcupineCtor.mockClear();
+
+    recorderInstances.length = 0;
+    PvRecorderCtor.mockClear();
+  });
+
+  it('announces readiness, emits wake events, and shuts down gracefully', async () => {
+    porcupineProcessQueue = [-1, 0, -1];
+
+    await import('../src/wake-word/porcupine-worker.js');
+
+    const readyMessage = await waitForMessage((message) => message.type === 'ready');
+    expect(readyMessage).toEqual({
+      type: 'ready',
+      info: {
+        frameLength: porcupineInstances[0].frameLength,
+        sampleRate: porcupineInstances[0].sampleRate,
+        keywordLabel: workerConfig.keywordLabel,
+      },
+    });
+
+    const wakeMessage = await waitForMessage((message) => message.type === 'wake');
+    expect(wakeMessage.type).toBe('wake');
+    expect(wakeMessage.event.keywordLabel).toBe(workerConfig.keywordLabel);
+    expect(wakeMessage.event.keywordIndex).toBe(0);
+    expect(wakeMessage.event.confidence).toBe(1);
+    expect(typeof wakeMessage.event.timestamp).toBe('number');
+
+    expect(PorcupineCtor).toHaveBeenCalledWith(
+      workerConfig.accessKey,
+      [workerConfig.keywordPath],
+      [workerConfig.sensitivity],
+      workerConfig.modelPath,
+    );
+
+    expect(PvRecorderCtor).toHaveBeenCalledWith(
+      porcupineInstances[0].frameLength,
+      workerConfig.deviceIndex,
+      50,
+    );
+
+    expect(recorderInstances[0].start).toHaveBeenCalledTimes(1);
+
+    parentPortEmitter.emit('message', { type: 'shutdown' });
+    await flushAsync();
+    await flushAsync();
+
+    expect(recorderInstances[0].stop).toHaveBeenCalledTimes(1);
+    expect(recorderInstances[0].release).toHaveBeenCalledTimes(1);
+    expect(porcupineInstances[0].release).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports recorder failures as serialized errors', async () => {
+    recorderReadQueue = [() => Promise.reject(new Error('mic failure'))];
+
+    await import('../src/wake-word/porcupine-worker.js');
+
+    const errorMessage = await waitForMessage((message) => message.type === 'error');
+    expect(errorMessage).toEqual({
+      type: 'error',
+      error: expect.objectContaining({
+        message: 'mic failure',
+        name: 'Error',
+      }),
+    });
+
+    parentPortEmitter.emit('message', { type: 'shutdown' });
+    await flushAsync();
+    await flushAsync();
+
+    expect(recorderInstances[0].stop).toHaveBeenCalledTimes(1);
+    expect(recorderInstances[0].release).toHaveBeenCalledTimes(1);
+    expect(porcupineInstances[0].release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/main/tests/preload.test.ts
+++ b/app/main/tests/preload.test.ts
@@ -28,11 +28,12 @@ describe('preload bridge', () => {
     await import('../src/preload.js');
   });
 
-  it('registers the aiembodied api with config bridge', async () => {
+  it('registers the aiembodied api with config bridge and ping helper', async () => {
     expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
     const [key, api] = exposeInMainWorld.mock.calls[0];
     expect(key).toBe('aiembodied');
     expect(api.config).toBeDefined();
+    expect(api.ping()).toBe('pong');
 
     invoke.mockResolvedValueOnce({ hasRealtimeApiKey: true });
     await expect(api.config.get()).resolves.toEqual({ hasRealtimeApiKey: true });

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -4,12 +4,17 @@ function usePing(): string {
   const [value, setValue] = useState('...');
 
   useEffect(() => {
-    const api = (window as unknown as { aiembodied?: { ping: () => string } }).aiembodied;
-    if (api) {
-      setValue(api.ping());
-    } else {
-      setValue('unavailable');
+    const api = (window as unknown as { aiembodied?: { ping?: () => string } }).aiembodied;
+    if (typeof api?.ping === 'function') {
+      try {
+        setValue(api.ping());
+        return;
+      } catch (error) {
+        console.error('Failed to call preload ping bridge', error);
+      }
     }
+
+    setValue('unavailable');
   }, []);
 
   return value;

--- a/app/renderer/tests/App.test.tsx
+++ b/app/renderer/tests/App.test.tsx
@@ -1,9 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import App from '../src/App';
 
+type PreloadWindow = Window & { aiembodied?: { ping?: () => string } };
+
 describe('App component', () => {
-  it('renders the MVP headline', () => {
+  const originalConsoleError = console.error;
+
+  beforeEach(() => {
+    (window as PreloadWindow).aiembodied = undefined;
+    console.error = vi.fn();
+  });
+
+  afterEach(() => {
+    (window as PreloadWindow).aiembodied = undefined;
+    console.error = originalConsoleError;
+  });
+
+  it('renders the MVP headline and bridge status when ping is available', () => {
+    (window as PreloadWindow).aiembodied = { ping: () => 'pong' };
+
     render(<App />);
-    expect(screen.getByText(/Embodied Assistant MVP/i)).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: /Embodied Assistant MVP/i })).toBeInTheDocument();
+    expect(screen.getByText(/Preload bridge status: pong/i)).toBeInTheDocument();
+  });
+
+  it('falls back to unavailable status when preload bridge is missing', () => {
+    render(<App />);
+
+    expect(screen.getByText(/Preload bridge status: unavailable/i)).toBeInTheDocument();
   });
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "typescript": "^5.4.4",
     "typescript-eslint": "^7.5.0",
     "vite": "^5.2.8",
-    "vitest": "^1.4.0"
+    "vitest": "^1.4.0",
+    "@vitest/coverage-v8": "^1.6.1"
   },
   "packageManager": "pnpm@9.12.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.7.0(vite@5.4.20(@types/node@20.19.19))
+      '@vitest/coverage-v8':
+        specifier: ^1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.19)(jsdom@24.1.3))
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -119,6 +122,10 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -209,6 +216,9 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -422,6 +432,10 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -460,7 +474,6 @@ packages:
   '@picovoice/porcupine-node@3.0.6':
     resolution: {integrity: sha512-vYlY0Hf9ovRB+Z9yyLReiVYZkLsm/kVPgDWTu2dgtqAooednohljfxSRzJUojapp8BFd7aW8P3H/4sm1zy49lw==}
     engines: {node: '>=18.0.0'}
-    cpu: ['!ia32', '!mips', '!ppc', '!ppc64']
 
   '@picovoice/pvrecorder-node@1.2.8':
     resolution: {integrity: sha512-dbLJlplQQNRkM2ja/hP4sRADGDILuJ54dEf8cU5eULeNrddxXvOtE8IiJ5F2VhhbXmIv3Qmn79DqhttCOxjH8Q==}
@@ -745,6 +758,11 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/coverage-v8@1.6.1':
+    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
+    peerDependencies:
+      vitest: 1.6.1
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -1450,6 +1468,9 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -1631,6 +1652,22 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -1741,6 +1778,13 @@ packages:
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -2296,6 +2340,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
@@ -2607,6 +2655,11 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -2728,6 +2781,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@colors/colors@1.6.0': {}
 
@@ -2878,6 +2933,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@istanbuljs/schema@0.1.3': {}
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -3208,6 +3265,25 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 5.4.20(@types/node@20.19.19)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@20.19.19)(jsdom@24.1.3))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.19
+      magicast: 0.3.5
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      test-exclude: 6.0.0
+      vitest: 1.6.1(@types/node@20.19.19)(jsdom@24.1.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4149,6 +4225,8 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  html-escaper@2.0.2: {}
+
   http-cache-semantics@4.2.0: {}
 
   http-proxy-agent@7.0.2:
@@ -4329,6 +4407,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -4461,6 +4560,16 @@ snapshots:
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
 
   make-error@1.3.6: {}
 
@@ -5080,6 +5189,12 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
 
   text-hex@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- replace the placeholder main-process test with thorough coverage of the bootstrap flow using mocked Electron, config, crash guard, and wake-word service collaborators
- add a Vitest suite for the Porcupine worker that exercises ready/wake/error messaging and shutdown resource cleanup
- note the new QA coverage activity in the project agent guide

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm --filter @aiembodied/main test -- --coverage

------
https://chatgpt.com/codex/tasks/task_b_68e15c3bde3c8330b906125b2d2eca13