### PR TITLE
feat: add renderer audio graph and device selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Track progress against `plan.md` here. Update the status markers (`[ ]` incomple
 - [x] 1. Configuration & Secrets Foundation
 - [x] 2. Logging & Crash Guard Infrastructure
 - [x] 3. Wake Word Service (Porcupine Worker) — Worker entrypoint adjusted for ts-node dev usage
-- [ ] 4. Audio Graph & Device Management
+- [x] 4. Audio Graph & Device Management
 - [ ] 5. Realtime Client (WebRTC Loop)
 - [ ] 6. Viseme Driver MVP
 - [ ] 7. Avatar Renderer (2D Canvas)

--- a/app/main/src/config/preferences-store.ts
+++ b/app/main/src/config/preferences-store.ts
@@ -1,0 +1,75 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface AudioDevicePreferences {
+  audioInputDeviceId?: string;
+  audioOutputDeviceId?: string;
+}
+
+export interface PreferencesStore {
+  load(): Promise<AudioDevicePreferences>;
+  save(preferences: AudioDevicePreferences): Promise<void>;
+}
+
+export class FilePreferencesStore implements PreferencesStore {
+  constructor(private readonly filePath: string) {}
+
+  async load(): Promise<AudioDevicePreferences> {
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      return this.sanitize(parsed);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {};
+      }
+
+      throw error;
+    }
+  }
+
+  async save(preferences: AudioDevicePreferences): Promise<void> {
+    const directory = path.dirname(this.filePath);
+    await fs.mkdir(directory, { recursive: true });
+    const payload = JSON.stringify(preferences, null, 2);
+    await fs.writeFile(this.filePath, payload, 'utf8');
+  }
+
+  private sanitize(input: Record<string, unknown>): AudioDevicePreferences {
+    const audioInputDeviceId = this.normalizeId(input.audioInputDeviceId);
+    const audioOutputDeviceId = this.normalizeId(input.audioOutputDeviceId);
+
+    const preferences: AudioDevicePreferences = {};
+
+    if (audioInputDeviceId) {
+      preferences.audioInputDeviceId = audioInputDeviceId;
+    }
+
+    if (audioOutputDeviceId) {
+      preferences.audioOutputDeviceId = audioOutputDeviceId;
+    }
+
+    return preferences;
+  }
+
+  private normalizeId(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+}
+
+export class InMemoryPreferencesStore implements PreferencesStore {
+  private preferences: AudioDevicePreferences = {};
+
+  async load(): Promise<AudioDevicePreferences> {
+    return { ...this.preferences };
+  }
+
+  async save(preferences: AudioDevicePreferences): Promise<void> {
+    this.preferences = { ...preferences };
+  }
+}

--- a/app/main/src/preload.ts
+++ b/app/main/src/preload.ts
@@ -1,10 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import type { ConfigSecretKey, RendererConfig } from './config/config-manager.js';
+import type { AudioDevicePreferences } from './config/preferences-store.js';
 import type { WakeWordDetectionEvent } from './wake-word/types.js';
 
 export interface ConfigBridge {
   get(): Promise<RendererConfig>;
   getSecret(key: ConfigSecretKey): Promise<string>;
+  setAudioDevicePreferences(preferences: AudioDevicePreferences): Promise<RendererConfig>;
 }
 
 export interface PreloadApi {
@@ -21,6 +23,8 @@ const api: PreloadApi = {
   config: {
     get: () => ipcRenderer.invoke('config:get') as Promise<RendererConfig>,
     getSecret: (key) => ipcRenderer.invoke('config:get-secret', key) as Promise<string>,
+    setAudioDevicePreferences: (preferences) =>
+      ipcRenderer.invoke('config:set-audio-devices', preferences) as Promise<RendererConfig>,
   },
   wakeWord: {
     onWake: (listener) => {

--- a/app/main/tests/preferences-store.test.ts
+++ b/app/main/tests/preferences-store.test.ts
@@ -1,0 +1,34 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FilePreferencesStore, InMemoryPreferencesStore } from '../src/config/preferences-store.js';
+
+describe('Preferences stores', () => {
+  it('returns stored values from the in-memory store', async () => {
+    const store = new InMemoryPreferencesStore();
+    await store.save({ audioInputDeviceId: 'mic', audioOutputDeviceId: 'speaker' });
+
+    await expect(store.load()).resolves.toEqual({
+      audioInputDeviceId: 'mic',
+      audioOutputDeviceId: 'speaker',
+    });
+  });
+
+  it('persists preferences to disk in the file store', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'prefs-'));
+    const filePath = path.join(directory, 'preferences.json');
+    const store = new FilePreferencesStore(filePath);
+
+    await expect(store.load()).resolves.toEqual({});
+
+    await store.save({ audioInputDeviceId: 'mic-1', audioOutputDeviceId: 'speaker-2' });
+    await expect(store.load()).resolves.toEqual({
+      audioInputDeviceId: 'mic-1',
+      audioOutputDeviceId: 'speaker-2',
+    });
+
+    const contents = await readFile(filePath, 'utf8');
+    expect(contents).toContain('mic-1');
+  });
+});

--- a/app/renderer/src/audio/audio-graph.ts
+++ b/app/renderer/src/audio/audio-graph.ts
@@ -1,0 +1,185 @@
+import { calculateRms, normalizeAudioLevel } from './metrics.js';
+import { VadController } from './vad-controller.js';
+
+export interface AudioGraphCallbacks {
+  onLevel?: (level: number) => void;
+  onSpeechActivityChange?: (isActive: boolean) => void;
+}
+
+export interface AudioGraphStartOptions {
+  inputDeviceId?: string;
+}
+
+export class AudioGraph {
+  private audioContext: AudioContext | null = null;
+  private inputStream: MediaStream | null = null;
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private upstreamDestination: MediaStreamAudioDestinationNode | null = null;
+  private gateNode: GainNode | null = null;
+  private levelAnalyser: AnalyserNode | null = null;
+  private visemeAnalyser: AnalyserNode | null = null;
+  private levelBuffer: (Float32Array & { buffer: ArrayBuffer }) | null = null;
+  private levelInterval: number | null = null;
+  private readonly vad = new VadController({ activationThreshold: 0.08, releaseMs: 250 });
+
+  constructor(private readonly callbacks: AudioGraphCallbacks = {}) {}
+
+  async start(options: AudioGraphStartOptions = {}): Promise<void> {
+    await this.stop();
+
+    const audioContextCtor = (window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext) as typeof AudioContext | undefined;
+
+    if (!audioContextCtor) {
+      throw new Error('Web Audio API is not available in this environment.');
+    }
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new Error('Media devices API is not available.');
+    }
+
+    const constraints: MediaStreamConstraints = {
+      audio: {
+        deviceId: options.inputDeviceId ? { exact: options.inputDeviceId } : undefined,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: 1,
+      },
+    };
+
+    const stream = await navigator.mediaDevices.getUserMedia(constraints);
+    const context = new audioContextCtor();
+    await context.resume();
+
+    const source = context.createMediaStreamSource(stream);
+    const gateNode = context.createGain();
+    gateNode.gain.value = 0;
+
+    const destination = context.createMediaStreamDestination();
+    gateNode.connect(destination);
+    source.connect(gateNode);
+
+    const levelAnalyser = context.createAnalyser();
+    levelAnalyser.fftSize = 2048;
+    levelAnalyser.smoothingTimeConstant = 0.7;
+    source.connect(levelAnalyser);
+
+    const visemeAnalyser = context.createAnalyser();
+    visemeAnalyser.fftSize = 2048;
+    visemeAnalyser.smoothingTimeConstant = 0.5;
+    source.connect(visemeAnalyser);
+
+    this.audioContext = context;
+    this.inputStream = stream;
+    this.sourceNode = source;
+    this.gateNode = gateNode;
+    this.upstreamDestination = destination;
+    this.levelAnalyser = levelAnalyser;
+    this.visemeAnalyser = visemeAnalyser;
+    this.levelBuffer = new Float32Array(
+      new ArrayBuffer(levelAnalyser.fftSize * Float32Array.BYTES_PER_ELEMENT),
+    ) as Float32Array & { buffer: ArrayBuffer };
+
+    this.startLevelMonitor();
+  }
+
+  async stop(): Promise<void> {
+    if (this.levelInterval !== null) {
+      window.clearInterval(this.levelInterval);
+      this.levelInterval = null;
+    }
+
+    this.vad.reset();
+
+    if (this.sourceNode) {
+      this.sourceNode.disconnect();
+      this.sourceNode = null;
+    }
+
+    if (this.gateNode) {
+      this.gateNode.disconnect();
+      this.gateNode = null;
+    }
+
+    if (this.upstreamDestination) {
+      this.upstreamDestination.disconnect();
+      this.upstreamDestination = null;
+    }
+
+    if (this.levelAnalyser) {
+      this.levelAnalyser.disconnect();
+      this.levelAnalyser = null;
+    }
+
+    if (this.visemeAnalyser) {
+      this.visemeAnalyser.disconnect();
+      this.visemeAnalyser = null;
+    }
+
+    if (this.inputStream) {
+      for (const track of this.inputStream.getTracks()) {
+        track.stop();
+      }
+      this.inputStream = null;
+    }
+
+    if (this.audioContext) {
+      await this.audioContext.close();
+      this.audioContext = null;
+    }
+
+    this.levelBuffer = null;
+  }
+
+  getUpstreamStream(): MediaStream | null {
+    return this.upstreamDestination?.stream ?? null;
+  }
+
+  getVisemeAnalyser(): AnalyserNode | null {
+    return this.visemeAnalyser;
+  }
+
+  private startLevelMonitor() {
+    if (!this.levelAnalyser || !this.levelBuffer) {
+      return;
+    }
+
+    const analyser = this.levelAnalyser;
+    const buffer = this.levelBuffer as unknown as Float32Array;
+
+    const tick = () => {
+      (analyser.getFloatTimeDomainData as unknown as (data: Float32Array) => void)(buffer);
+      const rms = calculateRms(buffer);
+      const normalized = normalizeAudioLevel(rms);
+
+      if (this.callbacks.onLevel) {
+        this.callbacks.onLevel(normalized);
+      }
+
+      const { isActive, changed } = this.vad.update(normalized, performance.now());
+
+      if (changed) {
+        this.applyGateState(isActive);
+        this.callbacks.onSpeechActivityChange?.(isActive);
+      }
+    };
+
+    this.levelInterval = window.setInterval(tick, 50);
+  }
+
+  private applyGateState(active: boolean) {
+    if (!this.gateNode || !this.audioContext) {
+      return;
+    }
+
+    const gain = this.gateNode.gain;
+    const targetValue = active ? 1 : 0;
+    const now = this.audioContext.currentTime;
+    if (typeof gain.setTargetAtTime === 'function') {
+      gain.setTargetAtTime(targetValue, now, 0.05);
+    } else {
+      gain.setValueAtTime(targetValue, now);
+    }
+  }
+}

--- a/app/renderer/src/audio/metrics.ts
+++ b/app/renderer/src/audio/metrics.ts
@@ -1,0 +1,22 @@
+export function calculateRms(samples: Float32Array): number {
+  if (samples.length === 0) {
+    return 0;
+  }
+
+  let sum = 0;
+  for (let index = 0; index < samples.length; index += 1) {
+    const value = samples[index];
+    sum += value * value;
+  }
+
+  return Math.sqrt(sum / samples.length);
+}
+
+export function normalizeAudioLevel(rms: number): number {
+  if (!Number.isFinite(rms) || rms <= 0) {
+    return 0;
+  }
+
+  const clamped = Math.min(1, Math.max(0, rms));
+  return Math.sqrt(clamped);
+}

--- a/app/renderer/src/audio/vad-controller.ts
+++ b/app/renderer/src/audio/vad-controller.ts
@@ -1,0 +1,42 @@
+export interface VadControllerOptions {
+  activationThreshold: number;
+  releaseMs: number;
+}
+
+export interface VadUpdateResult {
+  isActive: boolean;
+  changed: boolean;
+}
+
+export class VadController {
+  private isActive = false;
+  private lastActiveAt = 0;
+
+  constructor(private readonly options: VadControllerOptions) {}
+
+  update(level: number, timestampMs: number): VadUpdateResult {
+    if (Number.isNaN(level) || !Number.isFinite(level)) {
+      return { isActive: this.isActive, changed: false };
+    }
+
+    if (level >= this.options.activationThreshold) {
+      const changed = !this.isActive;
+      this.isActive = true;
+      this.lastActiveAt = timestampMs;
+      return { isActive: true, changed };
+    }
+
+    if (this.isActive && timestampMs - this.lastActiveAt <= this.options.releaseMs) {
+      return { isActive: true, changed: false };
+    }
+
+    const changed = this.isActive;
+    this.isActive = false;
+    return { isActive: false, changed };
+  }
+
+  reset() {
+    this.isActive = false;
+    this.lastActiveAt = 0;
+  }
+}

--- a/app/renderer/src/hooks/use-audio-devices.ts
+++ b/app/renderer/src/hooks/use-audio-devices.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface AudioDeviceSelection {
+  deviceId: string;
+  label: string;
+}
+
+interface AudioDevicesState {
+  inputs: AudioDeviceSelection[];
+  outputs: AudioDeviceSelection[];
+}
+
+export function useAudioDevices() {
+  const [devices, setDevices] = useState<AudioDevicesState>({ inputs: [], outputs: [] });
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) {
+      setDevices({ inputs: [], outputs: [] });
+      setError('Media devices enumeration is not supported in this environment.');
+      return;
+    }
+
+    try {
+      const mediaDevices = await navigator.mediaDevices.enumerateDevices();
+      const inputs: AudioDeviceSelection[] = [];
+      const outputs: AudioDeviceSelection[] = [];
+
+      for (const device of mediaDevices) {
+        if (device.kind === 'audioinput') {
+          inputs.push({ deviceId: device.deviceId, label: device.label || 'Microphone' });
+        } else if (device.kind === 'audiooutput') {
+          outputs.push({ deviceId: device.deviceId, label: device.label || 'Speaker' });
+        }
+      }
+
+      setDevices({ inputs, outputs });
+      setError(null);
+    } catch (deviceError) {
+      const message =
+        deviceError instanceof Error ? deviceError.message : 'Failed to enumerate audio devices.';
+      setDevices({ inputs: [], outputs: [] });
+      setError(message);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+
+    const handleDeviceChange = () => {
+      void refresh();
+    };
+
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices) {
+      return;
+    }
+
+    if (typeof mediaDevices.addEventListener === 'function') {
+      mediaDevices.addEventListener('devicechange', handleDeviceChange);
+      return () => {
+        mediaDevices.removeEventListener('devicechange', handleDeviceChange);
+      };
+    }
+
+    const originalHandler = mediaDevices.ondevicechange;
+    mediaDevices.ondevicechange = handleDeviceChange;
+    return () => {
+      mediaDevices.ondevicechange = originalHandler;
+    };
+  }, [refresh]);
+
+  return { ...devices, refresh, error };
+}

--- a/app/renderer/src/index.css
+++ b/app/renderer/src/index.css
@@ -10,16 +10,112 @@ body {
   margin: 0;
 }
 
-main.app {
+.app {
   min-height: 100vh;
+  margin: 0 auto;
+  padding: 2.5rem 3rem;
+  max-width: 960px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
+  gap: 2rem;
+  color: #0f172a;
 }
 
-h1 {
+.app__header h1 {
   font-size: 2.5rem;
   margin: 0;
+}
+
+.app__tagline {
+  margin: 0.25rem 0 0;
+  color: #475569;
+}
+
+.app__status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem 1.5rem;
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+}
+
+.app__status .label {
+  font-weight: 600;
+  margin-right: 0.25rem;
+}
+
+.app__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 220px;
+}
+
+.control label {
+  font-weight: 600;
+}
+
+.control select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  background: white;
+  font-size: 1rem;
+  color: inherit;
+  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.control select:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+  outline: none;
+}
+
+.app__meter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.meter {
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+  position: relative;
+}
+
+.meter__fill {
+  height: 100%;
+  background: linear-gradient(90deg, #38bdf8 0%, #2563eb 100%);
+  transition: width 0.1s ease-out;
+}
+
+.meter__label,
+.meter__status {
+  margin: 0;
+  color: #334155;
+  font-weight: 500;
+}
+
+.app__info {
+  margin: 0;
+  color: #2563eb;
+}
+
+.app__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: rgba(220, 38, 38, 0.1);
+  color: #b91c1c;
 }

--- a/app/renderer/src/preload-api.ts
+++ b/app/renderer/src/preload-api.ts
@@ -1,0 +1,5 @@
+export type PreloadApi = import('../../main/src/preload.js').PreloadApi;
+
+export function getPreloadApi(): PreloadApi | undefined {
+  return (window as unknown as { aiembodied?: PreloadApi }).aiembodied;
+}

--- a/app/renderer/tests/App.test.tsx
+++ b/app/renderer/tests/App.test.tsx
@@ -1,34 +1,175 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import App from '../src/App';
+import App from '../src/App.js';
 
-type PreloadWindow = Window & { aiembodied?: { ping?: () => string } };
+class MockMediaStream {
+  getTracks() {
+    return [];
+  }
+}
+
+class MockAnalyserNode {
+  fftSize = 2048;
+  smoothingTimeConstant = 0;
+  connect = vi.fn();
+  disconnect = vi.fn();
+  getFloatTimeDomainData = vi.fn((array: Float32Array) => {
+    array.fill(0);
+  });
+}
+
+class MockGainNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+  gain = {
+    value: 0,
+    setTargetAtTime: vi.fn(),
+    setValueAtTime: vi.fn(),
+  };
+}
+
+class MockMediaStreamSourceNode {
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class MockMediaStreamDestinationNode {
+  stream: MediaStream = new MockMediaStream() as unknown as MediaStream;
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+class MockAudioContext {
+  currentTime = 0;
+  createMediaStreamSource = vi.fn(() => new MockMediaStreamSourceNode() as unknown as MediaStreamAudioSourceNode);
+  createGain = vi.fn(() => new MockGainNode() as unknown as GainNode);
+  createMediaStreamDestination = vi.fn(
+    () => new MockMediaStreamDestinationNode() as unknown as MediaStreamAudioDestinationNode,
+  );
+  createAnalyser = vi.fn(() => new MockAnalyserNode() as unknown as AnalyserNode);
+  resume = vi.fn(async () => {});
+  close = vi.fn(async () => {});
+}
+
+type PreloadWindow = Window & { aiembodied?: import('../../main/src/preload.js').PreloadApi };
 
 describe('App component', () => {
+  const originalAudioContext = window.AudioContext;
+  const originalMediaDevices = navigator.mediaDevices;
   const originalConsoleError = console.error;
 
+  const enumerateDevicesMock = vi.fn();
+  const getUserMediaMock = vi.fn();
+  const setAudioDevicePreferencesMock = vi.fn();
+
   beforeEach(() => {
-    (window as PreloadWindow).aiembodied = undefined;
+    (window as unknown as { AudioContext: typeof AudioContext }).AudioContext = MockAudioContext as unknown as typeof AudioContext;
+    (navigator as Navigator & { mediaDevices: MediaDevices }).mediaDevices = {
+      enumerateDevices: enumerateDevicesMock,
+      getUserMedia: getUserMediaMock,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      ondevicechange: null,
+    } as unknown as MediaDevices;
+
+    enumerateDevicesMock.mockResolvedValue([
+      { deviceId: 'mic-1', kind: 'audioinput', label: 'USB Mic' },
+      { deviceId: 'speaker-1', kind: 'audiooutput', label: 'Speakers' },
+    ] as MediaDeviceInfo[]);
+    getUserMediaMock.mockResolvedValue(new MockMediaStream() as unknown as MediaStream);
+
+    setAudioDevicePreferencesMock.mockResolvedValue({
+      audioInputDeviceId: 'mic-1',
+      audioOutputDeviceId: '',
+      featureFlags: {},
+      hasRealtimeApiKey: true,
+      wakeWord: {
+        keywordPath: '',
+        keywordLabel: '',
+        sensitivity: 0.5,
+        minConfidence: 0.5,
+        cooldownMs: 1500,
+        deviceIndex: undefined,
+        modelPath: undefined,
+        hasAccessKey: true,
+      },
+    });
+
     console.error = vi.fn();
   });
 
   afterEach(() => {
-    (window as PreloadWindow).aiembodied = undefined;
+    (window as unknown as { AudioContext: typeof AudioContext }).AudioContext = originalAudioContext;
+    (navigator as Navigator & { mediaDevices: MediaDevices }).mediaDevices = originalMediaDevices;
+    Reflect.deleteProperty(window as PreloadWindow, 'aiembodied');
+    enumerateDevicesMock.mockReset();
+    getUserMediaMock.mockReset();
+    setAudioDevicePreferencesMock.mockReset();
     console.error = originalConsoleError;
   });
 
-  it('renders the MVP headline and bridge status when ping is available', () => {
-    (window as PreloadWindow).aiembodied = { ping: () => 'pong' };
+  it('renders audio controls and persists preference changes', async () => {
+    (window as PreloadWindow).aiembodied = {
+      ping: () => 'pong',
+      config: {
+        get: vi.fn().mockResolvedValue({
+          audioInputDeviceId: '',
+          audioOutputDeviceId: '',
+          featureFlags: {},
+          hasRealtimeApiKey: true,
+          wakeWord: {
+            keywordPath: '',
+            keywordLabel: '',
+            sensitivity: 0.5,
+            minConfidence: 0.5,
+            cooldownMs: 1500,
+            deviceIndex: undefined,
+            modelPath: undefined,
+            hasAccessKey: true,
+          },
+        }),
+        getSecret: vi.fn(),
+        setAudioDevicePreferences: setAudioDevicePreferencesMock,
+      },
+      wakeWord: {
+        onWake: vi.fn(),
+      },
+    } as unknown as PreloadWindow['aiembodied'];
 
     render(<App />);
 
-    expect(screen.getByRole('heading', { name: /Embodied Assistant MVP/i })).toBeInTheDocument();
-    expect(screen.getByText(/Preload bridge status: pong/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(enumerateDevicesMock).toHaveBeenCalled();
+    });
+
+    const inputSelect = await screen.findByLabelText('Microphone');
+    fireEvent.change(inputSelect, { target: { value: 'mic-1' } });
+
+    await waitFor(() => {
+      expect(setAudioDevicePreferencesMock).toHaveBeenCalledWith({
+        audioInputDeviceId: 'mic-1',
+        audioOutputDeviceId: undefined,
+      });
+    });
+
+    const speakerSelect = screen.getByLabelText('Speakers');
+    fireEvent.change(speakerSelect, { target: { value: 'speaker-1' } });
+
+    await waitFor(() => {
+      expect(setAudioDevicePreferencesMock).toHaveBeenLastCalledWith({
+        audioInputDeviceId: 'mic-1',
+        audioOutputDeviceId: 'speaker-1',
+      });
+    });
+
+    expect(screen.getByText(/Speech gate:/i)).toBeInTheDocument();
   });
 
-  it('falls back to unavailable status when preload bridge is missing', () => {
+  it('surfaces configuration errors when preload bridge is unavailable', async () => {
     render(<App />);
 
-    expect(screen.getByText(/Preload bridge status: unavailable/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/Renderer preload API is unavailable/i)).toBeInTheDocument();
+    });
   });
 });

--- a/app/renderer/tests/audio/metrics.test.ts
+++ b/app/renderer/tests/audio/metrics.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { calculateRms, normalizeAudioLevel } from '../../src/audio/metrics.js';
+
+describe('audio metrics helpers', () => {
+  it('computes the root mean square value for samples', () => {
+    const samples = new Float32Array([0, 0.5, -0.5, 1, -1]);
+    const rms = calculateRms(samples);
+
+    expect(rms).toBeGreaterThan(0);
+    expect(rms).toBeLessThanOrEqual(1);
+  });
+
+  it('normalizes audio level into perceptual scale', () => {
+    expect(normalizeAudioLevel(0)).toBe(0);
+    expect(normalizeAudioLevel(0.25)).toBeCloseTo(0.5, 2);
+    expect(normalizeAudioLevel(4)).toBe(1);
+  });
+});

--- a/app/renderer/tests/audio/vad-controller.test.ts
+++ b/app/renderer/tests/audio/vad-controller.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { VadController } from '../../src/audio/vad-controller.js';
+
+describe('VadController', () => {
+  it('activates when level exceeds threshold and holds for release window', () => {
+    const vad = new VadController({ activationThreshold: 0.2, releaseMs: 200 });
+
+    const first = vad.update(0.3, 0);
+    expect(first).toEqual({ isActive: true, changed: true });
+
+    const hold = vad.update(0.05, 150);
+    expect(hold).toEqual({ isActive: true, changed: false });
+
+    const release = vad.update(0.05, 300);
+    expect(release).toEqual({ isActive: false, changed: true });
+  });
+
+  it('remains inactive for low levels', () => {
+    const vad = new VadController({ activationThreshold: 0.4, releaseMs: 100 });
+    const result = vad.update(0.1, 0);
+    expect(result).toEqual({ isActive: false, changed: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add a preferences store to persist audio device selections and extend the config/IPCs to expose updates
- build the renderer audio graph with VAD gating, device selectors, and refreshed UI with status telemetry
- cover the new flow with renderer unit tests plus config/preferences store coverage

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e1d93750108330b30008dacafc6284