### PR TITLE
Add observability metrics exporter and developer HUD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Track progress against `plan.md` here. Update the status markers (`[ ]` incomple
 - [x] 8. Transcript Overlay & UI Shell — kiosk shell with transcript overlay toggle and wake/network indicators
 - [x] 9. Memory Store (SQLite)
 - [x] 10. Persistence in Conversation Loop
-- [ ] 11. Observability & Metrics
+- [x] 11. Observability & Metrics
 - [ ] 12. Packaging & Auto-Launch
 - [ ] 13. Appliance Readiness Validation
 - [ ] 14. Home Assistant Integration

--- a/app/main/package.json
+++ b/app/main/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^16.4.5",
     "electron": "^35.7.5",
     "keytar": "^7.9.0",
+    "prom-client": "^15.1.3",
     "winston": "^3.13.0",
     "winston-daily-rotate-file": "^5.0.0",
     "zod": "^3.22.4"

--- a/app/main/src/metrics/prometheus-collector.ts
+++ b/app/main/src/metrics/prometheus-collector.ts
@@ -1,0 +1,159 @@
+import http from 'node:http';
+import { collectDefaultMetrics, Histogram, Registry } from 'prom-client';
+import type { LatencyMetricName } from './types.js';
+
+export interface PrometheusCollectorOptions {
+  host?: string;
+  port?: number;
+  path?: string;
+  logger?: {
+    info: (message: string, data?: Record<string, unknown>) => void;
+    warn: (message: string, data?: Record<string, unknown>) => void;
+    error: (message: string, data?: Record<string, unknown>) => void;
+  };
+}
+
+export class PrometheusCollector {
+  private readonly registry = new Registry();
+
+  private readonly host: string;
+
+  private readonly port: number;
+
+  private readonly path: string;
+
+  private readonly logger?: PrometheusCollectorOptions['logger'];
+
+  private server: http.Server | null = null;
+
+  private readonly wakeToCapture: Histogram<string>;
+
+  private readonly captureToFirstAudio: Histogram<string>;
+
+  private readonly wakeToFirstAudio: Histogram<string>;
+
+  constructor(options: PrometheusCollectorOptions = {}) {
+    this.host = options.host ?? '127.0.0.1';
+    this.port = options.port ?? 9477;
+    this.path = options.path ?? '/metrics';
+    this.logger = options.logger;
+
+    collectDefaultMetrics({ register: this.registry });
+
+    const buckets = [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10];
+
+    this.wakeToCapture = new Histogram({
+      name: 'aiembodied_wake_to_capture_seconds',
+      help: 'Latency from wake word detection to microphone capture activation.',
+      buckets,
+      registers: [this.registry],
+    });
+
+    this.captureToFirstAudio = new Histogram({
+      name: 'aiembodied_capture_to_first_audio_seconds',
+      help: 'Latency from microphone capture activation to first assistant audio playback.',
+      buckets,
+      registers: [this.registry],
+    });
+
+    this.wakeToFirstAudio = new Histogram({
+      name: 'aiembodied_wake_to_first_audio_seconds',
+      help: 'Latency from wake word detection to first assistant audio playback.',
+      buckets,
+      registers: [this.registry],
+    });
+  }
+
+  async start(): Promise<void> {
+    if (this.server) {
+      return;
+    }
+
+    this.server = http.createServer(async (request, response) => {
+      const method = request.method ?? 'GET';
+      if (method !== 'GET') {
+        response.statusCode = 405;
+        response.setHeader('Content-Type', 'text/plain');
+        response.end('Method Not Allowed');
+        return;
+      }
+
+      const requestUrl = request.url ?? this.path;
+      const url = new URL(requestUrl, `http://${request.headers.host ?? `${this.host}:${this.port}`}`);
+      if (url.pathname !== this.path) {
+        response.statusCode = 404;
+        response.setHeader('Content-Type', 'text/plain');
+        response.end('Not Found');
+        return;
+      }
+
+      try {
+        const metrics = await this.registry.metrics();
+        response.statusCode = 200;
+        response.setHeader('Content-Type', this.registry.contentType);
+        response.end(metrics);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to serialize metrics.';
+        this.logger?.error('Failed to serialize metrics', { message });
+        response.statusCode = 500;
+        response.setHeader('Content-Type', 'text/plain');
+        response.end('Internal Server Error');
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.server?.once('error', (error) => {
+        this.logger?.error('Metrics server failed to start', { message: (error as Error).message });
+        reject(error);
+      });
+
+      this.server?.listen(this.port, this.host, () => {
+        this.logger?.info('Prometheus metrics exporter listening', {
+          host: this.host,
+          port: this.port,
+          path: this.path,
+        });
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      this.server?.close((error) => {
+        if (error) {
+          this.logger?.warn('Error while shutting down metrics server', { message: error.message });
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+
+    this.server = null;
+  }
+
+  observeLatency(metric: LatencyMetricName, valueMs: number): void {
+    const valueSeconds = Math.max(0, valueMs) / 1000;
+
+    switch (metric) {
+      case 'wake_to_capture_ms':
+        this.wakeToCapture.observe(valueSeconds);
+        break;
+      case 'capture_to_first_audio_ms':
+        this.captureToFirstAudio.observe(valueSeconds);
+        break;
+      case 'wake_to_first_audio_ms':
+        this.wakeToFirstAudio.observe(valueSeconds);
+        break;
+    }
+  }
+
+  async metrics(): Promise<string> {
+    return this.registry.metrics();
+  }
+}

--- a/app/main/src/metrics/types.ts
+++ b/app/main/src/metrics/types.ts
@@ -1,0 +1,9 @@
+export type LatencyMetricName =
+  | 'wake_to_capture_ms'
+  | 'capture_to_first_audio_ms'
+  | 'wake_to_first_audio_ms';
+
+export interface LatencyObservation {
+  metric: LatencyMetricName;
+  valueMs: number;
+}

--- a/app/main/tests/config-manager.test.ts
+++ b/app/main/tests/config-manager.test.ts
@@ -96,6 +96,27 @@ describe('ConfigManager', () => {
     });
   });
 
+  it('parses metrics configuration from environment variables', async () => {
+    const manager = new ConfigManager({
+      env: {
+        REALTIME_API_KEY: 'key',
+        PORCUPINE_ACCESS_KEY: 'wake-key',
+        METRICS_ENABLED: 'true',
+        METRICS_HOST: '0.0.0.0',
+        METRICS_PORT: '9100',
+        METRICS_PATH: 'metrics-endpoint',
+      } as NodeJS.ProcessEnv,
+    });
+
+    const config = await manager.load();
+    expect(config.metrics).toEqual({
+      enabled: true,
+      host: '0.0.0.0',
+      port: 9100,
+      path: '/metrics-endpoint',
+    });
+  });
+
   it('throws a validation error when the realtime api key is missing', async () => {
     const manager = new ConfigManager({
       env: { PORCUPINE_ACCESS_KEY: 'wake-key' } as NodeJS.ProcessEnv,

--- a/app/main/tests/metrics/prometheus-collector.test.ts
+++ b/app/main/tests/metrics/prometheus-collector.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { PrometheusCollector } from '../../src/metrics/prometheus-collector.js';
+
+describe('PrometheusCollector', () => {
+  it('records latency observations and exposes histogram metrics', async () => {
+    const collector = new PrometheusCollector({ host: '127.0.0.1', port: 0 });
+
+    collector.observeLatency('wake_to_capture_ms', 250);
+    collector.observeLatency('capture_to_first_audio_ms', 500);
+    collector.observeLatency('wake_to_first_audio_ms', 750);
+
+    const metrics = await collector.metrics();
+
+    expect(metrics).toContain('aiembodied_wake_to_capture_seconds_count 1');
+    expect(metrics).toContain('aiembodied_capture_to_first_audio_seconds_count 1');
+    expect(metrics).toContain('aiembodied_wake_to_first_audio_seconds_count 1');
+  });
+
+  it('starts and stops an HTTP server when requested', async () => {
+    const collector = new PrometheusCollector({ host: '127.0.0.1', port: 0 });
+
+    await collector.start();
+    await collector.stop();
+  });
+});

--- a/app/renderer/src/index.css
+++ b/app/renderer/src/index.css
@@ -206,6 +206,61 @@ main {
   color: #f8fafc;
 }
 
+.kiosk__hud {
+  position: absolute;
+  left: 3rem;
+  bottom: 3rem;
+  width: clamp(260px, 24vw, 360px);
+  background: rgba(2, 6, 23, 0.82);
+  border-radius: 16px;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(14px);
+  pointer-events: none;
+}
+
+.kiosk__hudTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(191, 219, 254, 0.85);
+}
+
+.kiosk__hudMetrics {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.kiosk__hudMetrics > div {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.55rem 0.85rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.kiosk__hudMetrics dt {
+  margin: 0;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.85rem;
+}
+
+.kiosk__hudMetrics dd {
+  margin: 0;
+  color: #f8fafc;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
 .kiosk__meter {
   display: flex;
   flex-direction: column;
@@ -365,5 +420,11 @@ main {
 
   .kiosk__statusBar {
     gap: 0.5rem;
+  }
+
+  .kiosk__hud {
+    position: static;
+    width: auto;
+    margin-top: 1rem;
   }
 }

--- a/app/renderer/src/metrics/latency-tracker.ts
+++ b/app/renderer/src/metrics/latency-tracker.ts
@@ -1,0 +1,102 @@
+export interface LatencySnapshot {
+  wakeToCaptureMs?: number;
+  captureToFirstAudioMs?: number;
+  wakeToFirstAudioMs?: number;
+}
+
+interface LatencyCycle {
+  wakeTimestamp: number;
+  sessionId?: string | null;
+  captureTimestamp?: number;
+  firstAudioTimestamp?: number;
+}
+
+export class LatencyTracker {
+  private cycle: LatencyCycle | null = null;
+
+  private lastSnapshot: LatencySnapshot | null = null;
+
+  beginCycle(wakeTimestamp: number, sessionId?: string | null): void {
+    this.cycle = {
+      wakeTimestamp,
+      sessionId: sessionId ?? null,
+      captureTimestamp: undefined,
+      firstAudioTimestamp: undefined,
+    };
+    this.lastSnapshot = null;
+  }
+
+  recordCapture(timestamp: number, sessionId?: string | null): LatencySnapshot | null {
+    if (!this.cycle) {
+      return null;
+    }
+
+    if (this.cycle.captureTimestamp !== undefined) {
+      return null;
+    }
+
+    if (this.cycle.sessionId && sessionId && this.cycle.sessionId !== sessionId) {
+      return null;
+    }
+
+    this.cycle.captureTimestamp = timestamp;
+
+    const snapshot: LatencySnapshot = {};
+
+    if (Number.isFinite(this.cycle.wakeTimestamp)) {
+      snapshot.wakeToCaptureMs = Math.max(0, timestamp - this.cycle.wakeTimestamp);
+    }
+
+    this.mergeSnapshot(snapshot);
+    return Object.keys(snapshot).length ? snapshot : null;
+  }
+
+  recordFirstAudio(timestamp: number, sessionId?: string | null): LatencySnapshot | null {
+    if (!this.cycle) {
+      return null;
+    }
+
+    if (this.cycle.firstAudioTimestamp !== undefined) {
+      return null;
+    }
+
+    if (this.cycle.sessionId && sessionId && this.cycle.sessionId !== sessionId) {
+      return null;
+    }
+
+    this.cycle.firstAudioTimestamp = timestamp;
+
+    const snapshot: LatencySnapshot = {};
+
+    if (this.cycle.captureTimestamp !== undefined) {
+      snapshot.captureToFirstAudioMs = Math.max(0, timestamp - this.cycle.captureTimestamp);
+    }
+
+    if (Number.isFinite(this.cycle.wakeTimestamp)) {
+      snapshot.wakeToFirstAudioMs = Math.max(0, timestamp - this.cycle.wakeTimestamp);
+    }
+
+    this.mergeSnapshot(snapshot);
+    return Object.keys(snapshot).length ? snapshot : null;
+  }
+
+  reset(): void {
+    this.cycle = null;
+    this.lastSnapshot = null;
+  }
+
+  getLastSnapshot(): LatencySnapshot | null {
+    return this.lastSnapshot;
+  }
+
+  private mergeSnapshot(snapshot: LatencySnapshot): void {
+    if (!Object.keys(snapshot).length) {
+      return;
+    }
+
+    this.lastSnapshot = {
+      ...(this.lastSnapshot ?? {}),
+      ...snapshot,
+    };
+  }
+}

--- a/app/renderer/tests/metrics/latency-tracker.test.ts
+++ b/app/renderer/tests/metrics/latency-tracker.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { LatencyTracker } from '../../src/metrics/latency-tracker.js';
+
+describe('LatencyTracker', () => {
+  it('records wake to capture latency', () => {
+    const tracker = new LatencyTracker();
+    tracker.beginCycle(1000, 'session-1');
+
+    const snapshot = tracker.recordCapture(1600, 'session-1');
+
+    expect(snapshot).toEqual({ wakeToCaptureMs: 600 });
+    expect(tracker.getLastSnapshot()).toEqual({ wakeToCaptureMs: 600 });
+  });
+
+  it('records capture to first audio and wake to first audio latencies', () => {
+    const tracker = new LatencyTracker();
+    tracker.beginCycle(500, 'session-2');
+    tracker.recordCapture(900, 'session-2');
+
+    const snapshot = tracker.recordFirstAudio(1500, 'session-2');
+
+    expect(snapshot).toEqual({ captureToFirstAudioMs: 600, wakeToFirstAudioMs: 1000 });
+    expect(tracker.getLastSnapshot()).toEqual({
+      wakeToCaptureMs: 400,
+      captureToFirstAudioMs: 600,
+      wakeToFirstAudioMs: 1000,
+    });
+  });
+
+  it('ignores events for mismatched session ids', () => {
+    const tracker = new LatencyTracker();
+    tracker.beginCycle(0, 'session-a');
+
+    const capture = tracker.recordCapture(200, 'session-b');
+    const audio = tracker.recordFirstAudio(400, 'session-b');
+
+    expect(capture).toBeNull();
+    expect(audio).toBeNull();
+    expect(tracker.getLastSnapshot()).toBeNull();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       keytar:
         specifier: ^7.9.0
         version: 7.9.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       winston:
         specifier: ^3.13.0
         version: 3.18.3
@@ -477,10 +480,13 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@picovoice/porcupine-node@3.0.6':
     resolution: {integrity: sha512-vYlY0Hf9ovRB+Z9yyLReiVYZkLsm/kVPgDWTu2dgtqAooednohljfxSRzJUojapp8BFd7aW8P3H/4sm1zy49lw==}
     engines: {node: '>=18.0.0'}
-    cpu: ['!ia32', '!mips', '!ppc', '!ppc64']
 
   '@picovoice/pvrecorder-node@1.2.8':
     resolution: {integrity: sha512-dbLJlplQQNRkM2ja/hP4sRADGDILuJ54dEf8cU5eULeNrddxXvOtE8IiJ5F2VhhbXmIv3Qmn79DqhttCOxjH8Q==}
@@ -911,6 +917,9 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2062,6 +2071,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2359,6 +2372,9 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -2996,6 +3012,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@picovoice/porcupine-node@3.0.6': {}
 
   '@picovoice/pvrecorder-node@1.2.8': {}
@@ -3468,6 +3486,8 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -4846,6 +4866,11 @@ snapshots:
 
   progress@2.0.3: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -5224,6 +5249,10 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   test-exclude@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add a Prometheus-based metrics collector with optional config wiring and IPC exposure
- capture wake/capture/audio latencies in the renderer and surface a developer HUD overlay
- cover new metrics paths with unit tests and extend main bootstrap expectations

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e22b44adf4833098c5ab444000c5e1