### PR TITLE
Add cross-platform dependency setup scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,4 @@ Keep this checklist accurate; it is the authoritative tracker for execution stat
 - 2025-10-06 — Introduced a pull request template checklist to enforce lint, typecheck, and test runs before merges.
 - 2025-10-07 — Refreshed the README with a full project overview and setup instructions sourced from PRD/architecture docs.
 - 2025-10-08 — Removed the kiosk packaging icon asset pending refreshed branding deliverables.
+- 2025-10-09 — Added cross-platform setup scripts to validate/install Node.js and pnpm prerequisites.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ Check `AGENTS.md` for the authoritative status checklist that mirrors these mile
 - Picovoice Porcupine access key (free tier available) for wake-word detection.
 - OpenAI Realtime API access with a corresponding key.
 
+#### Automated environment bootstrap
+
+To streamline installing the runtime prerequisites, run the helper script for your
+platform from the repository root:
+
+```powershell
+# Windows PowerShell
+.\scripts\setup-windows.ps1
+```
+
+```bash
+# macOS Terminal
+./scripts/setup-macos.sh
+```
+
+The scripts verify existing installations of Node.js and pnpm, upgrading them when
+necessary via the native package manager (`winget`/Chocolatey on Windows, Homebrew on
+macOS). When the checks pass you can continue with `pnpm install`.
+
 ### Clone & Install
 
 ```bash

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REQUIRED_NODE_VERSION="20.0.0"
+TARGET_PNPM_VERSION="9.12.0"
+
+version_ge() {
+  local current="$1"
+  local required="$2"
+  if [[ "$(printf '%s\n%s\n' "$required" "$current" | sort -V | tail -n1)" == "$current" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+has_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+get_node_version() {
+  if ! has_command node; then
+    return 1
+  fi
+  node --version | tr -d 'v'
+}
+
+ensure_homebrew() {
+  if has_command brew; then
+    return
+  fi
+  cat <<'MSG'
+Homebrew is required to install Node.js automatically on macOS but was not found.
+Install Homebrew from https://brew.sh/ and re-run this script.
+MSG
+  exit 1
+}
+
+ensure_node() {
+  local current
+  if current=$(get_node_version); then
+    if version_ge "$current" "$REQUIRED_NODE_VERSION"; then
+      echo "Node.js ${current} already satisfies the minimum requirement."
+      return
+    fi
+  fi
+
+  echo "Installing Node.js via Homebrew..."
+  ensure_homebrew
+  brew update
+  if brew list node >/dev/null 2>&1; then
+    brew upgrade node
+  else
+    brew install node
+  fi
+
+  if ! current=$(get_node_version); then
+    echo "Node.js installation failed." >&2
+    exit 1
+  fi
+
+  if ! version_ge "$current" "$REQUIRED_NODE_VERSION"; then
+    echo "Node.js ${current} does not meet the ${REQUIRED_NODE_VERSION}+ requirement." >&2
+    exit 1
+  fi
+
+  echo "Node.js ${current} is ready."
+}
+
+get_pnpm_version() {
+  if ! has_command pnpm; then
+    return 1
+  fi
+  pnpm --version
+}
+
+ensure_pnpm() {
+  if ! has_command corepack; then
+    echo "Corepack was not found. Verify that Node.js 16.17+ is installed." >&2
+    exit 1
+  fi
+
+  local current
+  if current=$(get_pnpm_version); then
+    if version_ge "$current" "$TARGET_PNPM_VERSION"; then
+      echo "pnpm ${current} already satisfies the requirement."
+      return
+    fi
+  fi
+
+  echo "Activating pnpm ${TARGET_PNPM_VERSION} via Corepack..."
+  corepack enable
+  corepack prepare "pnpm@${TARGET_PNPM_VERSION}" --activate
+
+  if ! current=$(get_pnpm_version); then
+    echo "Failed to activate pnpm via Corepack." >&2
+    exit 1
+  fi
+
+  echo "pnpm ${current} is ready."
+}
+
+ensure_node
+ensure_pnpm
+
+echo "All dependencies are installed. You can now run 'pnpm install'."

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,0 +1,121 @@
+#requires -version 5.1
+<#!
+.SYNOPSIS
+    Prepares a Windows developer workstation for the Embodied ChatGPT Assistant project.
+.DESCRIPTION
+    Ensures that Node.js (v20 or newer) and pnpm are installed. Existing installations
+    are reused when they meet the minimum requirements. Node.js is installed via winget
+    (or Chocolatey as a fallback) and pnpm is provisioned through Corepack so the version
+    aligns with the repository's packageManager field.
+!>
+
+$ErrorActionPreference = 'Stop'
+
+$RequiredNodeVersion = [Version]'20.0.0'
+$TargetPnpmVersion = '9.12.0'
+
+function Test-CommandExists {
+    param (
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+    try {
+        return [bool](Get-Command -Name $Name -ErrorAction Stop)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Get-NodeVersion {
+    if (-not (Test-CommandExists -Name 'node')) {
+        return $null
+    }
+
+    $rawVersion = node --version 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($rawVersion)) {
+        return $null
+    }
+
+    return [Version]($rawVersion.Trim().TrimStart('v', 'V'))
+}
+
+function Ensure-Node {
+    $nodeVersion = Get-NodeVersion
+    if ($null -ne $nodeVersion -and $nodeVersion -ge $RequiredNodeVersion) {
+        Write-Host "Node.js $($nodeVersion.ToString()) already satisfies the minimum requirement." -ForegroundColor Green
+        return
+    }
+
+    Write-Host "Installing or upgrading Node.js to meet the $RequiredNodeVersion requirement..." -ForegroundColor Cyan
+
+    if (Test-CommandExists -Name 'winget') {
+        winget install --id OpenJS.NodeJS.LTS --source winget --exact --accept-package-agreements --accept-source-agreements
+    }
+    elseif (Test-CommandExists -Name 'choco') {
+        choco install nodejs-lts --yes --no-progress
+    }
+    else {
+        throw 'Neither winget nor Chocolatey were found. Install one of them and re-run this script.'
+    }
+
+    $nodeVersion = Get-NodeVersion
+    if ($null -eq $nodeVersion -or $nodeVersion -lt $RequiredNodeVersion) {
+        throw "Node.js installation did not succeed or is still older than $RequiredNodeVersion."
+    }
+
+    Write-Host "Node.js $($nodeVersion.ToString()) is ready." -ForegroundColor Green
+}
+
+function Get-PnpmVersion {
+    if (-not (Test-CommandExists -Name 'pnpm')) {
+        return $null
+    }
+
+    $rawVersion = pnpm --version 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($rawVersion)) {
+        return $null
+    }
+
+    return $rawVersion.Trim()
+}
+
+function Ensure-Pnpm {
+    if (-not (Test-CommandExists -Name 'corepack')) {
+        throw 'Corepack was not found. Verify that Node.js 16.17+ is installed.'
+    }
+
+    $currentVersion = Get-PnpmVersion
+    if ($null -ne $currentVersion) {
+        try {
+            if ([Version]$currentVersion -ge [Version]$TargetPnpmVersion) {
+                Write-Host "pnpm $currentVersion already satisfies the requirement." -ForegroundColor Green
+                return
+            }
+        }
+        catch {
+            Write-Warning "Unable to parse pnpm version '$currentVersion'. Reinstalling via Corepack."
+        }
+    }
+
+    Write-Host "Activating pnpm $TargetPnpmVersion via Corepack..." -ForegroundColor Cyan
+    corepack enable
+    corepack prepare "pnpm@$TargetPnpmVersion" --activate
+
+    $currentVersion = Get-PnpmVersion
+    if ($null -eq $currentVersion) {
+        throw 'Failed to activate pnpm via Corepack.'
+    }
+
+    Write-Host "pnpm $currentVersion is ready." -ForegroundColor Green
+}
+
+try {
+    Ensure-Node
+    Ensure-Pnpm
+
+    Write-Host "All dependencies are installed. You can now run 'pnpm install'." -ForegroundColor Green
+}
+catch {
+    Write-Error $_
+    exit 1
+}


### PR DESCRIPTION
## Summary
- add macOS and Windows helper scripts that verify/install Node.js 20+ and pnpm 9.12
- document the scripted bootstrap option in the README
- log the tooling addition in the engineering agent guide

## Testing
- pnpm install
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68e284ef64648330aa1bd34af50ef322