### PR TITLE
feat: manage configuration api secrets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,4 @@ Keep this checklist accurate; it is the authoritative tracker for execution stat
 - 2025-10-06 — Introduced a pull request template checklist to enforce lint, typecheck, and test runs before merges.
 - 2025-10-07 — Refreshed the README with a full project overview and setup instructions sourced from PRD/architecture docs.
 - 2025-10-08 — Removed the kiosk packaging icon asset pending refreshed branding deliverables.
+- 2025-10-09 — Added renderer configuration secret management with associated unit tests for update and validation flows.

--- a/app/main/src/main.ts
+++ b/app/main/src/main.ts
@@ -100,6 +100,10 @@ function registerIpcHandlers(
 ) {
   ipcMain.handle('config:get', () => manager.getRendererConfig());
   ipcMain.handle('config:get-secret', (_event, key: ConfigSecretKey) => manager.getSecret(key));
+  ipcMain.handle('config:set-secret', (_event, payload: { key: ConfigSecretKey; value: string }) =>
+    manager.setSecret(payload.key, payload.value),
+  );
+  ipcMain.handle('config:test-secret', (_event, key: ConfigSecretKey) => manager.testSecret(key));
   ipcMain.handle('config:set-audio-devices', (_event, preferences) =>
     manager.setAudioDevicePreferences(preferences),
   );

--- a/app/main/src/preload.ts
+++ b/app/main/src/preload.ts
@@ -14,6 +14,8 @@ export interface ConfigBridge {
   get(): Promise<RendererConfig>;
   getSecret(key: ConfigSecretKey): Promise<string>;
   setAudioDevicePreferences(preferences: AudioDevicePreferences): Promise<RendererConfig>;
+  setSecret(key: ConfigSecretKey, value: string): Promise<RendererConfig>;
+  testSecret(key: ConfigSecretKey): Promise<{ ok: boolean; message?: string }>;
 }
 
 export interface PreloadApi {
@@ -43,6 +45,10 @@ const api: PreloadApi = {
   config: {
     get: () => ipcRenderer.invoke('config:get') as Promise<RendererConfig>,
     getSecret: (key) => ipcRenderer.invoke('config:get-secret', key) as Promise<string>,
+    setSecret: (key, value) =>
+      ipcRenderer.invoke('config:set-secret', { key, value }) as Promise<RendererConfig>,
+    testSecret: (key) =>
+      ipcRenderer.invoke('config:test-secret', key) as Promise<{ ok: boolean; message?: string }>,
     setAudioDevicePreferences: (preferences) =>
       ipcRenderer.invoke('config:set-audio-devices', preferences) as Promise<RendererConfig>,
   },

--- a/app/main/src/types/vendor.d.ts
+++ b/app/main/src/types/vendor.d.ts
@@ -1,0 +1,45 @@
+declare module 'auto-launch' {
+  export interface AutoLaunchOptions {
+    name: string;
+    path?: string;
+    isHidden?: boolean;
+    mac?: {
+      useLaunchAgent?: boolean;
+    };
+  }
+
+  export default class AutoLaunch {
+    constructor(options: AutoLaunchOptions);
+    enable(): Promise<void>;
+    disable(): Promise<void>;
+    isEnabled(): Promise<boolean>;
+  }
+}
+
+declare module 'prom-client' {
+  export interface CollectDefaultMetricsOptions {
+    register?: Registry;
+  }
+
+  export function collectDefaultMetrics(options?: CollectDefaultMetricsOptions): void;
+
+  export class Registry {
+    contentType: string;
+    registerMetric(metric: Histogram): void;
+    metrics(): Promise<string>;
+  }
+
+  export interface HistogramConfiguration<T extends string = string> {
+    name: string;
+    help: string;
+    buckets?: number[];
+    labelNames?: T[];
+    registers?: Registry[];
+  }
+
+  export class Histogram<T extends string = string> {
+    constructor(configuration: HistogramConfiguration<T>);
+    observe(value: number): void;
+    observe(labels: Record<T, string>, value: number): void;
+  }
+}

--- a/app/main/tests/setup.ts
+++ b/app/main/tests/setup.ts
@@ -1,0 +1,47 @@
+import { vi } from 'vitest';
+
+vi.mock('prom-client', () => {
+  class MockHistogram {
+    public name: string;
+    private count = 0;
+
+    constructor(configuration: { name: string; registers?: Array<{ registerMetric: (histogram: MockHistogram) => void }> }) {
+      this.name = configuration.name;
+      for (const registry of configuration.registers ?? []) {
+        registry.registerMetric(this);
+      }
+    }
+
+    observe(valueOrLabels: number | Record<string, string>, maybeValue?: number): void {
+      const value = typeof valueOrLabels === 'number' ? valueOrLabels : maybeValue;
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        this.count += 1;
+      }
+    }
+
+    metrics(): string {
+      return `${this.name}_count ${this.count}`;
+    }
+  }
+
+  class MockRegistry {
+    contentType = 'text/plain';
+    private readonly metricsList: MockHistogram[] = [];
+
+    registerMetric(metric: MockHistogram): void {
+      this.metricsList.push(metric);
+    }
+
+    async metrics(): Promise<string> {
+      return this.metricsList.map((metric) => metric.metrics()).join('\n');
+    }
+  }
+
+  const collectDefaultMetrics = vi.fn();
+
+  return {
+    Histogram: MockHistogram,
+    Registry: MockRegistry,
+    collectDefaultMetrics,
+  };
+});

--- a/app/main/vitest.config.ts
+++ b/app/main/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    setupFiles: ['tests/setup.ts'],
   },
 });

--- a/app/renderer/src/index.css
+++ b/app/renderer/src/index.css
@@ -295,6 +295,120 @@ main {
   gap: 1.5rem;
 }
 
+.kiosk__secrets {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.kiosk__secrets h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #f8fafc;
+}
+
+.kiosk__helper {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
+  max-width: 720px;
+}
+
+.kiosk__secretList {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.secretCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.35);
+}
+
+.secretCard[data-configured='false'] {
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.secretCard__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.secretCard__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #f8fafc;
+}
+
+.secretCard__description {
+  margin: 0;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.secretCard__status {
+  margin: 0;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.secretCard__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.secretCard__form input {
+  padding: 0.6rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(2, 6, 23, 0.75);
+  color: #f8fafc;
+  font-size: 1rem;
+  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.secretCard__form input:focus {
+  border-color: rgba(59, 130, 246, 0.75);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+  outline: none;
+}
+
+.secretCard__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.secretCard__actions button {
+  background: rgba(59, 130, 246, 0.2);
+  color: #e0f2fe;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  border-radius: 999px;
+  padding: 0.55rem 1.35rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out, transform 0.2s ease-in-out, opacity 0.2s ease-in-out;
+}
+
+.secretCard__actions button:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.3);
+  transform: translateY(-1px);
+}
+
+.secretCard__actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .control {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add secure secret update and validation hooks to the config manager and preload bridge
- expose API key management controls in the renderer configuration view with supporting styles
- extend unit tests and supporting infrastructure for secret workflows and metrics mocks

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e28567a1088330a2145c1d89048245