### PR TITLE
Fix Windows setup script comment block and pnpm version detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,4 @@ Keep this checklist accurate; it is the authoritative tracker for execution stat
 - 2025-10-07 — Refreshed the README with a full project overview and setup instructions sourced from PRD/architecture docs.
 - 2025-10-08 — Removed the kiosk packaging icon asset pending refreshed branding deliverables.
 - 2025-10-09 — Added cross-platform setup scripts to validate/install Node.js and pnpm prerequisites.
+- 2025-10-10 — Patched the Windows setup script comment-based help and automated pnpm version detection from package.json.


### PR DESCRIPTION
## Summary
- correct the Windows setup script comment-based help delimiters so PowerShell can parse the file
- derive the pnpm version requirement from package.json to stay aligned with the repository configuration

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e3fd451cd88330b7163ea68015ff6b