### PR TITLE
Handle pnpm activation without admin rights

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,5 @@ Keep this checklist accurate; it is the authoritative tracker for execution stat
 - 2025-10-07 — Refreshed the README with a full project overview and setup instructions sourced from PRD/architecture docs.
 - 2025-10-08 — Removed the kiosk packaging icon asset pending refreshed branding deliverables.
 - 2025-10-09 — Added cross-platform setup scripts to validate/install Node.js and pnpm prerequisites.
+- 2025-10-10 — Patched the Windows setup script comment-based help and automated pnpm version detection from package.json.
+- 2025-10-11 — Added a Corepack permission fallback to download pnpm to a user directory and persist PATH updates.

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,5 +1,5 @@
 #requires -version 5.1
-<#!
+<#
 .SYNOPSIS
     Prepares a Windows developer workstation for the Embodied ChatGPT Assistant project.
 .DESCRIPTION
@@ -7,12 +7,45 @@
     are reused when they meet the minimum requirements. Node.js is installed via winget
     (or Chocolatey as a fallback) and pnpm is provisioned through Corepack so the version
     aligns with the repository's packageManager field.
-!>
+#>
 
 $ErrorActionPreference = 'Stop'
 
 $RequiredNodeVersion = [Version]'20.0.0'
-$TargetPnpmVersion = '9.12.0'
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDirectory '..')
+
+function Get-TargetPnpmVersionFromPackageJson {
+    $packageJsonPath = Join-Path $repoRoot 'package.json'
+    if (-not (Test-Path -Path $packageJsonPath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        $packageJson = Get-Content -Path $packageJsonPath -Raw | ConvertFrom-Json
+    }
+    catch {
+        Write-Warning "Unable to parse package.json to determine target pnpm version."
+        return $null
+    }
+
+    if (-not $packageJson.packageManager) {
+        return $null
+    }
+
+    $parts = $packageJson.packageManager -split '@', 2
+    if ($parts.Length -ne 2 -or [string]::IsNullOrWhiteSpace($parts[1])) {
+        Write-Warning "packageManager field in package.json is not in the expected 'pnpm@<version>' format."
+        return $null
+    }
+
+    return $parts[1]
+}
+
+$TargetPnpmVersion = Get-TargetPnpmVersionFromPackageJson
+if (-not $TargetPnpmVersion) {
+    $TargetPnpmVersion = '9.12.0'
+}
 
 function Test-CommandExists {
     param (
@@ -79,11 +112,85 @@ function Get-PnpmVersion {
     return $rawVersion.Trim()
 }
 
-function Ensure-Pnpm {
-    if (-not (Test-CommandExists -Name 'corepack')) {
-        throw 'Corepack was not found. Verify that Node.js 16.17+ is installed.'
+function Get-PnpmStandaloneDirectory {
+    if ($env:LOCALAPPDATA) {
+        return Join-Path $env:LOCALAPPDATA 'pnpm'
     }
 
+    if ($env:USERPROFILE) {
+        return Join-Path $env:USERPROFILE '.pnpm'
+    }
+
+    return Join-Path ([System.IO.Path]::GetTempPath()) 'pnpm'
+}
+
+function Ensure-Directory {
+    param (
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    if (-not (Test-Path -Path $Path -PathType Container)) {
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+$script:UserPathUpdated = $false
+
+function Add-ToUserPath {
+    param (
+        [Parameter(Mandatory = $true)][string]$PathToAdd
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathToAdd)) {
+        return
+    }
+
+    $currentUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $userPathSegments = if ([string]::IsNullOrWhiteSpace($currentUserPath)) { @() } else { $currentUserPath.Split(';') }
+
+    if (-not ($userPathSegments -contains $PathToAdd)) {
+        $newUserPath = if ([string]::IsNullOrWhiteSpace($currentUserPath)) { $PathToAdd } else { "$currentUserPath;$PathToAdd" }
+        [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+        $script:UserPathUpdated = $true
+    }
+
+    if (-not ($env:Path.Split(';') -contains $PathToAdd)) {
+        $env:Path = "$PathToAdd;$env:Path"
+    }
+}
+
+function Install-PnpmStandalone {
+    param (
+        [Parameter(Mandatory = $true)][string]$Version
+    )
+
+    $installDirectory = Get-PnpmStandaloneDirectory
+    Ensure-Directory -Path $installDirectory
+
+    $downloadUri = "https://github.com/pnpm/pnpm/releases/download/v$Version/pnpm-win-x64.exe"
+    $destinationPath = Join-Path $installDirectory 'pnpm.exe'
+
+    Write-Host "Downloading pnpm $Version to a user-writable directory..." -ForegroundColor Cyan
+
+    try {
+        if ([Net.ServicePointManager]::SecurityProtocol -band [Net.SecurityProtocolType]::Tls12 -eq 0) {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        }
+        Invoke-WebRequest -Uri $downloadUri -OutFile $destinationPath -UseBasicParsing | Out-Null
+    }
+    catch {
+        throw "Failed to download pnpm $Version from $downloadUri. $_"
+    }
+
+    if (-not (Test-Path -Path $destinationPath -PathType Leaf)) {
+        throw "pnpm executable was not created at $destinationPath."
+    }
+
+    Add-ToUserPath -PathToAdd $installDirectory
+    Write-Host "pnpm $Version downloaded to $installDirectory." -ForegroundColor Green
+}
+
+function Ensure-Pnpm {
     $currentVersion = Get-PnpmVersion
     if ($null -ne $currentVersion) {
         try {
@@ -97,13 +204,38 @@ function Ensure-Pnpm {
         }
     }
 
-    Write-Host "Activating pnpm $TargetPnpmVersion via Corepack..." -ForegroundColor Cyan
-    corepack enable
-    corepack prepare "pnpm@$TargetPnpmVersion" --activate
+    $activated = $false
+
+    if (Test-CommandExists -Name 'corepack') {
+        Write-Host "Activating pnpm $TargetPnpmVersion via Corepack..." -ForegroundColor Cyan
+        try {
+            corepack enable
+            corepack prepare "pnpm@$TargetPnpmVersion" --activate
+            $activated = $true
+        }
+        catch {
+            $message = $_.Exception.Message
+            if ($message -match 'EPERM' -or $message -match 'EACCES' -or $message -match 'Access is denied') {
+                Write-Warning "Corepack could not activate pnpm due to insufficient permissions. Falling back to a standalone download."
+                Install-PnpmStandalone -Version $TargetPnpmVersion
+            }
+            else {
+                throw
+            }
+        }
+    }
+    else {
+        Write-Warning 'Corepack was not found. Downloading a standalone pnpm build instead.'
+        Install-PnpmStandalone -Version $TargetPnpmVersion
+    }
 
     $currentVersion = Get-PnpmVersion
     if ($null -eq $currentVersion) {
-        throw 'Failed to activate pnpm via Corepack.'
+        if ($activated) {
+            throw 'Failed to activate pnpm via Corepack.'
+        }
+
+        throw 'Failed to provision pnpm. Review the warnings above and try running this script from an elevated PowerShell session.'
     }
 
     Write-Host "pnpm $currentVersion is ready." -ForegroundColor Green
@@ -114,6 +246,9 @@ try {
     Ensure-Pnpm
 
     Write-Host "All dependencies are installed. You can now run 'pnpm install'." -ForegroundColor Green
+    if ($script:UserPathUpdated) {
+        Write-Host 'A user-level PATH update was applied. Restart existing shells to pick up the new pnpm location.' -ForegroundColor Yellow
+    }
 }
 catch {
     Write-Error $_


### PR DESCRIPTION
## Summary
- correct the Windows setup script comment-based help delimiters so PowerShell can parse the file
- derive the pnpm version requirement from package.json to stay aligned with the repository configuration
- add a permission-aware fallback that downloads pnpm to a user-writable directory and updates the PATH when Corepack activation fails

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e3fd451cd88330b7163ea68015ff6b