### PR TITLE
Fix renderer base path for packaged builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,4 @@ Keep this checklist accurate; it is the authoritative tracker for execution stat
 - 2025-10-12 — Adjusted main dev script to use Node ESM loader; validated end-to-end app launch via Electron with rebuilt native deps.
 - 2025-10-13 — Corrected Windows Join-Path usage in run-dev script to reliably detect missing .env configuration.
 - 2025-10-13 — Added opt-in diagnostics instrumentation to capture Electron lifecycle and renderer console logs for black screen debugging.
+- 2025-10-14 — Updated renderer build base path configuration to fix blank Electron window on Windows and added regression coverage.

--- a/app/renderer/tests/vite-config.test.ts
+++ b/app/renderer/tests/vite-config.test.ts
@@ -1,0 +1,36 @@
+import config from '../vite.config';
+import type { ConfigEnv, UserConfig } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+type Mode = 'development' | 'production';
+
+type ConfigExport = typeof config;
+
+type ConfigFactory = Extract<ConfigExport, (env: ConfigEnv) => UserConfig | Promise<UserConfig>>;
+
+type ConfigValue = Extract<ConfigExport, UserConfig | Promise<UserConfig>>;
+
+async function resolveConfig(mode: Mode): Promise<UserConfig> {
+  const env: ConfigEnv = {
+    mode,
+    command: mode === 'development' ? 'serve' : 'build',
+  };
+
+  const result = typeof config === 'function'
+    ? (config as ConfigFactory)(env)
+    : (config as ConfigValue);
+
+  return await Promise.resolve(result);
+}
+
+describe('vite configuration', () => {
+  it('uses an absolute base path during development', async () => {
+    const resolved = await resolveConfig('development');
+    expect(resolved.base).toBe('/');
+  });
+
+  it('uses a relative base path for production builds', async () => {
+    const resolved = await resolveConfig('production');
+    expect(resolved.base).toBe('./');
+  });
+});

--- a/app/renderer/vite.config.ts
+++ b/app/renderer/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  base: mode === 'development' ? '/' : './',
   plugins: [react()],
   test: {
     environment: 'jsdom',
@@ -9,4 +10,4 @@ export default defineConfig({
     setupFiles: './vitest.setup.ts',
     include: ['tests/**/*.test.tsx'],
   },
-});
+}));


### PR DESCRIPTION
## Summary
- ensure the renderer build uses a relative base path so packaged Electron apps load assets correctly
- add a vitest to guard the production and development base path configuration and update the QA log

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68e66d05dd5883308b7003af530dc490