### PR TITLE
Handle missing realtime API key and stabilize preload bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,4 @@ Keep this checklist accurate; it is the authoritative tracker for execution stat
 - 2025-10-13 — Corrected Windows Join-Path usage in run-dev script to reliably detect missing .env configuration.
 - 2025-10-13 — Added opt-in diagnostics instrumentation to capture Electron lifecycle and renderer console logs for black screen debugging.
 - 2025-10-14 — Updated renderer build base path configuration to fix blank Electron window on Windows and added regression coverage.
+- 2025-10-15 — Relaxed realtime key boot requirements, added preload bridge resilience, and expanded config manager tests.


### PR DESCRIPTION
## Summary
- allow the ConfigManager to boot when the realtime API key is absent, accept lowercase environment variables, and surface clearer validation errors when testing secrets
- extend the ConfigManager test suite to cover realtime keyless startup, environment fallbacks, and missing-key validation
- harden the renderer preload bridge hook so the configuration screen recovers if the bridge is exposed late
- document the recent QA activity update in AGENTS.md

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e6702820a48330ab4f677e87d64192