### PR TITLE
Add Meshy API key support and Meshy IPC contracts (steps 1-2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,3 +141,4 @@ Refer to `plan.md`, `archspec.md`, and `prd.md` for the authoritative product an
 - 2025-12-29 — VRM relaxed pose now uses IK-based iterative solver (`setNaturalArmPose` in `vrm-avatar-renderer.tsx`) instead of fixed rotation angles. Algorithm measures actual arm length from skeleton, defines dynamic target position (8cm to side, 85% of arm length down), and iteratively adjusts shoulder/elbow rotations to converge within 0.5cm. Works model-agnostic; logs detailed metrics (iterations, error in cm, target/achieved positions) for debugging. See `RELAXED_POSE_FIX.md` for implementation details.
 - 2025-03-08 — Added a design-only Meshy API integration plan in `meshy-plan.md`.
 - 2025-03-08 — Appended a step-by-step build plan to `meshy-plan.md`.
+- 2025-03-09 — Completed Meshy plan steps 1-2 by confirming scope against `prd.md`/`archspec.md`/`plan.md` and defining Meshy config + IPC data contracts.

--- a/app/main/src/avatar/types.ts
+++ b/app/main/src/avatar/types.ts
@@ -67,6 +67,29 @@ export interface AvatarPoseGenerationRequest {
   modelDescription?: string;
 }
 
+export type MeshyJobStatus = 'queued' | 'generating' | 'rigging' | 'completed' | 'failed';
+
+export interface MeshyModelGenerationRequest {
+  prompt: string;
+}
+
+export interface MeshyModelGenerationResult {
+  jobId: string;
+}
+
+export interface MeshyModelStatus {
+  jobId: string;
+  status: MeshyJobStatus;
+  progress?: number;
+  previewPath?: string | null;
+  fbxPath?: string | null;
+  errorMessage?: string | null;
+}
+
+export interface MeshyModelAcceptanceResult {
+  vrmId: string;
+}
+
 // VRM 1.0 expression preset names
 export type VrmExpressionPresetName =
   | 'happy' | 'angry' | 'sad' | 'relaxed' | 'surprised' | 'neutral'  // emotions

--- a/app/main/src/config/config-manager.ts
+++ b/app/main/src/config/config-manager.ts
@@ -10,6 +10,7 @@ export type FeatureFlags = Record<string, boolean>;
 
 export interface AppConfig {
   realtimeApiKey: string;
+  meshyApiKey: string;
   audioInputDeviceId?: string;
   audioOutputDeviceId?: string;
   realtimeModel?: string;
@@ -46,12 +47,13 @@ export type RendererWakeWordConfig = Omit<WakeWordConfig, 'accessKey'> & {
   hasAccessKey: boolean;
 };
 
-export type RendererConfig = Omit<AppConfig, 'realtimeApiKey' | 'wakeWord'> & {
+export type RendererConfig = Omit<AppConfig, 'realtimeApiKey' | 'meshyApiKey' | 'wakeWord'> & {
   hasRealtimeApiKey: boolean;
+  hasMeshyApiKey: boolean;
   wakeWord: RendererWakeWordConfig;
 };
 
-export type ConfigSecretKey = 'realtimeApiKey' | 'wakeWordAccessKey';
+export type ConfigSecretKey = 'realtimeApiKey' | 'wakeWordAccessKey' | 'meshyApiKey';
 
 type OpenAIModelsClient = {
   models?: {
@@ -102,9 +104,10 @@ const MetricsSchema = z.object({
 });
 
 const RealtimeApiKeySchema = z.string().min(1, 'Realtime API key is required');
+const MeshyApiKeySchema = z.string().min(1, 'Meshy API key is required');
 const WakeWordAccessKeySchema = z.string().min(1, 'Porcupine access key is required');
 
-const DEFAULT_SECRET_KEYS: ConfigSecretKey[] = ['realtimeApiKey', 'wakeWordAccessKey'];
+const DEFAULT_SECRET_KEYS: ConfigSecretKey[] = ['realtimeApiKey', 'wakeWordAccessKey', 'meshyApiKey'];
 
 export class ConfigManager {
   private config: AppConfig | null = null;
@@ -138,6 +141,7 @@ export class ConfigManager {
 
     const realtimeApiKey = await this.resolveRealtimeApiKey();
     const wakeWordAccessKey = await this.resolveWakeWordAccessKey();
+    const meshyApiKey = await this.resolveMeshyApiKey();
     const storedPreferences = (await this.preferencesStore?.load()) ?? {};
 
     if (!wakeWordAccessKey) {
@@ -155,6 +159,7 @@ export class ConfigManager {
 
     const config: AppConfig = {
       realtimeApiKey: realtimeApiKey ?? '',
+      meshyApiKey: meshyApiKey ?? '',
       audioInputDeviceId,
       audioOutputDeviceId,
       realtimeModel: this.normalizeDeviceId(storedPreferences.realtimeModel),
@@ -174,6 +179,7 @@ export class ConfigManager {
     this.config = config;
     this.logger.info('Configuration loaded.', {
       hasRealtimeApiKey: Boolean(config.realtimeApiKey),
+      hasMeshyApiKey: Boolean(config.meshyApiKey),
       wakeWordHasAccessKey: Boolean(config.wakeWord.accessKey),
       audioInputConfigured: Boolean(config.audioInputDeviceId),
       audioOutputConfigured: Boolean(config.audioOutputDeviceId),
@@ -237,13 +243,14 @@ export class ConfigManager {
 
   getRendererConfig(): RendererConfig {
     const config = this.getConfig();
-    const { realtimeApiKey, wakeWord, ...rest } = config;
+    const { realtimeApiKey, meshyApiKey, wakeWord, ...rest } = config;
 
     const { accessKey, ...rendererWakeWord } = wakeWord;
 
     return {
       ...rest,
       hasRealtimeApiKey: Boolean(realtimeApiKey),
+      hasMeshyApiKey: Boolean(meshyApiKey),
       wakeWord: {
         ...rendererWakeWord,
         hasAccessKey: Boolean(accessKey),
@@ -263,6 +270,10 @@ export class ConfigManager {
 
     if (key === 'wakeWordAccessKey') {
       return config.wakeWord.accessKey;
+    }
+
+    if (key === 'meshyApiKey') {
+      return config.meshyApiKey;
     }
 
     throw new Error(`Unhandled secret key requested: ${key}`);
@@ -300,6 +311,17 @@ export class ConfigManager {
       return this.getRendererConfig();
     }
 
+    if (key === 'meshyApiKey') {
+      const parsed = MeshyApiKeySchema.parse(trimmed);
+      await this.persistSecret('MESHY_API_KEY', parsed);
+      this.config = {
+        ...this.config,
+        meshyApiKey: parsed,
+      };
+      this.logger.info('Meshy API key updated.', { length: parsed.length });
+      return this.getRendererConfig();
+    }
+
     throw new Error(`Unhandled secret key update requested: ${key}`);
   }
 
@@ -326,6 +348,13 @@ export class ConfigManager {
       }
       this.logger.debug('Testing wake word access key.');
       return this.testWakeWordKey(fetchFn, this.config.wakeWord.accessKey);
+    }
+
+    if (key === 'meshyApiKey') {
+      if (!this.config.meshyApiKey) {
+        return { ok: false, message: 'Meshy API key is not configured.' };
+      }
+      return { ok: false, message: 'Meshy API key validation is not available yet.' };
     }
 
     throw new Error(`Unhandled secret test requested: ${key}`);
@@ -385,6 +414,35 @@ export class ConfigManager {
       this.logger.debug('Wake word access key resolved from secret store.', { length: stored.length });
     } else {
       this.logger.error('Wake word access key not found in secret store.');
+    }
+    return stored ?? undefined;
+  }
+
+  private async resolveMeshyApiKey(): Promise<string | undefined> {
+    this.logger.debug('Resolving Meshy API key from environment variables.', {
+      keys: ['MESHY_API_KEY', 'meshy_api_key'],
+    });
+    const envValue = this.readSecretFromEnv(['MESHY_API_KEY', 'meshy_api_key']);
+    if (envValue) {
+      this.logger.debug('Meshy API key resolved from environment variables.', {
+        length: envValue.length,
+      });
+      return envValue;
+    }
+
+    this.logger.debug('Meshy API key not found in environment.', {
+      hasSecretStore: Boolean(this.secretStore),
+    });
+    if (!this.secretStore) {
+      this.logger.warn('Meshy API key unavailable: secret store is not configured.');
+      return undefined;
+    }
+
+    const stored = await this.secretStore.getSecret('MESHY_API_KEY');
+    if (stored) {
+      this.logger.debug('Meshy API key resolved from secret store.', { length: stored.length });
+    } else {
+      this.logger.warn('Meshy API key not found in secret store.');
     }
     return stored ?? undefined;
   }

--- a/app/main/src/main.ts
+++ b/app/main/src/main.ts
@@ -471,6 +471,7 @@ function registerIpcHandlers(
 
   const summarizeRendererConfig = (config: RendererConfig) => ({
     hasRealtimeApiKey: config.hasRealtimeApiKey,
+    hasMeshyApiKey: config.hasMeshyApiKey,
     wakeWordHasAccessKey: config.wakeWord?.hasAccessKey ?? false,
     audioInputConfigured: Boolean(config.audioInputDeviceId),
     audioOutputConfigured: Boolean(config.audioOutputDeviceId),
@@ -1251,6 +1252,7 @@ app.whenReady().then(async () => {
   logger.info('Renderer bridge readiness state.', {
     config: {
       hasRealtimeApiKey: Boolean(configSnapshot.realtimeApiKey),
+      hasMeshyApiKey: Boolean(configSnapshot.meshyApiKey),
       hasWakeWordAccessKey: Boolean(configSnapshot.wakeWord.accessKey),
     },
     avatar: { enabled: Boolean(avatarModelService) },

--- a/app/main/src/preload.ts
+++ b/app/main/src/preload.ts
@@ -15,6 +15,10 @@ import type {
   AvatarPoseGenerationRequest,
   PoseEvaluationRequest,
   PoseEvaluationResult,
+  MeshyModelGenerationRequest,
+  MeshyModelGenerationResult,
+  MeshyModelStatus,
+  MeshyModelAcceptanceResult,
 } from './avatar/types.js';
 import type {
   ConversationAppendMessagePayload,
@@ -186,6 +190,10 @@ export interface AvatarBridge {
   loadPose(poseId: string): Promise<unknown>;
   evaluatePose(request: PoseEvaluationRequest): Promise<PoseEvaluationResult>;
   refinePose(request: PoseEvaluationRequest): Promise<AvatarPoseUploadResult>;
+  generateMeshyModel(request: MeshyModelGenerationRequest): Promise<MeshyModelGenerationResult>;
+  getMeshyStatus(jobId: string): Promise<MeshyModelStatus>;
+  acceptMeshyModel(jobId: string): Promise<MeshyModelAcceptanceResult>;
+  rejectMeshyModel(jobId: string): Promise<void>;
 }
 
 export interface CameraDetectionEvent {
@@ -355,6 +363,15 @@ const api: PreloadApi & { __bridgeReady: boolean; __bridgeVersion: string } = {
       ipcRenderer.invoke('avatar-pose:evaluate', payload) as Promise<PoseEvaluationResult>,
     refinePose: (payload: PoseEvaluationRequest) =>
       ipcRenderer.invoke('avatar-pose:refine', payload) as Promise<AvatarPoseUploadResult>,
+    generateMeshyModel: (payload: MeshyModelGenerationRequest) =>
+      ipcRenderer.invoke('avatar:meshy-generate', payload) as Promise<MeshyModelGenerationResult>,
+    getMeshyStatus: (jobId: string) =>
+      ipcRenderer.invoke('avatar:meshy-status', jobId) as Promise<MeshyModelStatus>,
+    acceptMeshyModel: (jobId: string) =>
+      ipcRenderer.invoke('avatar:meshy-accept', jobId) as Promise<MeshyModelAcceptanceResult>,
+    rejectMeshyModel: async (jobId: string) => {
+      await ipcRenderer.invoke('avatar:meshy-reject', jobId);
+    },
   },
   camera: {
     onDetection: (listener) => {

--- a/app/main/tests/config-manager.test.ts
+++ b/app/main/tests/config-manager.test.ts
@@ -8,6 +8,7 @@ describe('ConfigManager', () => {
     const manager = new ConfigManager({
       env: {
         REALTIME_API_KEY: 'test-api-key',
+        MESHY_API_KEY: 'meshy-key',
         PORCUPINE_ACCESS_KEY: 'porcupine-key',
         AUDIO_INPUT_DEVICE_ID: 'input-device',
         AUDIO_OUTPUT_DEVICE_ID: 'output-device',
@@ -24,6 +25,7 @@ describe('ConfigManager', () => {
 
     expect(config.audioInputDeviceId).toBe('input-device');
     expect(config.audioOutputDeviceId).toBe('output-device');
+    expect(config.meshyApiKey).toBe('meshy-key');
   });
 
   it('prefers stored preferences over environment configuration', async () => {
@@ -36,6 +38,7 @@ describe('ConfigManager', () => {
     const manager = new ConfigManager({
       env: {
         REALTIME_API_KEY: 'test-api-key',
+        MESHY_API_KEY: 'meshy-key',
         PORCUPINE_ACCESS_KEY: 'porcupine-key',
         AUDIO_INPUT_DEVICE_ID: 'env-input',
         AUDIO_OUTPUT_DEVICE_ID: 'env-output',
@@ -60,11 +63,13 @@ describe('ConfigManager', () => {
 
     await expect(manager.getSecret('realtimeApiKey')).resolves.toBe('test-api-key');
     await expect(manager.getSecret('wakeWordAccessKey')).resolves.toBe('porcupine-key');
+    await expect(manager.getSecret('meshyApiKey')).resolves.toBe('meshy-key');
   });
 
   it('falls back to secret store when environment variable is missing', async () => {
     const secretStore = new InMemorySecretStore();
     await secretStore.setSecret('REALTIME_API_KEY', 'stored-key');
+    await secretStore.setSecret('MESHY_API_KEY', 'meshy-secret');
     await secretStore.setSecret('PORCUPINE_ACCESS_KEY', 'porcupine-secret');
 
     const manager = new ConfigManager({
@@ -74,6 +79,7 @@ describe('ConfigManager', () => {
 
     const config = await manager.load();
     expect(config.realtimeApiKey).toBe('stored-key');
+    expect(config.meshyApiKey).toBe('meshy-secret');
     expect(config.wakeWord.accessKey).toBe('porcupine-secret');
     expect(config.wakeWord.keywordPath).toBe('bumblebee');
     expect(config.wakeWord.keywordLabel).toBe('Bumblebee');
@@ -155,6 +161,7 @@ describe('ConfigManager', () => {
     const manager = new ConfigManager({
       env: {
         realtime_api_key: ' \trealtime-key \n',
+        meshy_api_key: ' meshy-key ',
         porcupine_access_key: '  porcupine-key  ',
         WAKE_WORD_BUILTIN: 'porcupine',
       } as NodeJS.ProcessEnv,
@@ -163,6 +170,7 @@ describe('ConfigManager', () => {
     const config = await manager.load();
 
     expect(config.realtimeApiKey).toBe('realtime-key');
+    expect(config.meshyApiKey).toBe('meshy-key');
     expect(config.wakeWord.accessKey).toBe('porcupine-key');
     expect(config.wakeWord.keywordPath).toBe('porcupine');
     expect(config.wakeWord.keywordLabel).toBe('Porcupine');
@@ -178,6 +186,7 @@ describe('ConfigManager', () => {
 
     const env = {
       REALTIME_API_KEY: 'rt-secret-value',
+      MESHY_API_KEY: 'meshy-secret-value',
       PORCUPINE_ACCESS_KEY: 'wake-secret-value',
       WAKE_WORD_BUILTIN: 'porcupine',
     } as NodeJS.ProcessEnv;
@@ -191,6 +200,10 @@ describe('ConfigManager', () => {
       expect.objectContaining({ length: env.REALTIME_API_KEY.length }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
+      'Meshy API key resolved from environment variables.',
+      expect.objectContaining({ length: env.MESHY_API_KEY.length }),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
       'Wake word access key resolved from environment variables.',
       expect.objectContaining({ length: env.PORCUPINE_ACCESS_KEY.length }),
     );
@@ -198,6 +211,7 @@ describe('ConfigManager', () => {
       'Configuration loaded.',
       expect.objectContaining({
         hasRealtimeApiKey: true,
+        hasMeshyApiKey: true,
         wakeWordHasAccessKey: true,
       }),
     );
@@ -205,8 +219,27 @@ describe('ConfigManager', () => {
     for (const call of [...logger.debug.mock.calls, ...logger.info.mock.calls]) {
       const serialized = JSON.stringify(call);
       expect(serialized).not.toContain(env.REALTIME_API_KEY);
+      expect(serialized).not.toContain(env.MESHY_API_KEY);
       expect(serialized).not.toContain(env.PORCUPINE_ACCESS_KEY);
     }
+  });
+
+  it('stores and reports Meshy API keys through the config manager', async () => {
+    const secretStore = new InMemorySecretStore();
+    const manager = new ConfigManager({
+      env: { PORCUPINE_ACCESS_KEY: 'wake-key' } as NodeJS.ProcessEnv,
+      secretStore,
+    });
+
+    await manager.load();
+
+    const rendererConfig = await manager.setSecret('meshyApiKey', 'meshy-updated');
+    expect(rendererConfig.hasMeshyApiKey).toBe(true);
+    await expect(manager.getSecret('meshyApiKey')).resolves.toBe('meshy-updated');
+    await expect(manager.testSecret('meshyApiKey')).resolves.toEqual({
+      ok: false,
+      message: 'Meshy API key validation is not available yet.',
+    });
   });
 
   it('updates and persists audio device preferences', async () => {

--- a/app/main/tests/main.test.ts
+++ b/app/main/tests/main.test.ts
@@ -502,6 +502,7 @@ describe('main process bootstrap', () => {
 
     const config = {
       realtimeApiKey: 'rt-key',
+      meshyApiKey: 'meshy-key',
       featureFlags: {},
       wakeWord: {
         accessKey: 'access',
@@ -538,6 +539,7 @@ describe('main process bootstrap', () => {
   it('initializes wake word service, ipc handlers, and window lifecycle on ready', async () => {
     const baseConfig = {
       realtimeApiKey: 'rt-key',
+      meshyApiKey: 'meshy-key',
       audioInputDeviceId: undefined,
       audioOutputDeviceId: undefined,
       featureFlags: {},
@@ -563,11 +565,11 @@ describe('main process bootstrap', () => {
 
     loadMock.mockResolvedValue(baseConfig);
     getConfigMock.mockImplementation(() => currentConfig);
-    getRendererConfigMock.mockReturnValue({ hasRealtimeApiKey: true });
-    setAudioDevicePreferencesMock.mockImplementation(async () => ({ hasRealtimeApiKey: true }));
+    getRendererConfigMock.mockReturnValue({ hasRealtimeApiKey: true, hasMeshyApiKey: true });
+    setAudioDevicePreferencesMock.mockImplementation(async () => ({ hasRealtimeApiKey: true, hasMeshyApiKey: true }));
     setSecretMock.mockImplementation(async (_key: string, value: string) => {
       currentConfig = { ...currentConfig, realtimeApiKey: value };
-      return { hasRealtimeApiKey: true };
+      return { hasRealtimeApiKey: true, hasMeshyApiKey: true };
     });
     testSecretMock.mockResolvedValue({ ok: true });
 
@@ -666,6 +668,7 @@ describe('main process bootstrap', () => {
     expect(typeof configHandler).toBe('function');
     await expect(configHandler?.({} as unknown as IpcMainInvokeEvent)).resolves.toEqual({
       hasRealtimeApiKey: true,
+      hasMeshyApiKey: true,
     });
 
     const secretHandler = handleEntries.get('config:get-secret');
@@ -678,6 +681,7 @@ describe('main process bootstrap', () => {
     expect(typeof setSecretHandler).toBe('function');
     await expect(setSecretHandler?.({}, { key: 'realtimeApiKey', value: 'next-key' })).resolves.toEqual({
       hasRealtimeApiKey: true,
+      hasMeshyApiKey: true,
     });
     expect(setSecretMock).toHaveBeenCalledWith('realtimeApiKey', 'next-key');
 
@@ -940,6 +944,7 @@ describe('main process bootstrap', () => {
 
     const baseConfig = {
       realtimeApiKey: 'rt-key',
+      meshyApiKey: 'meshy-key',
       audioInputDeviceId: undefined,
       audioOutputDeviceId: undefined,
       featureFlags: {},
@@ -961,9 +966,9 @@ describe('main process bootstrap', () => {
 
     loadMock.mockResolvedValue(baseConfig);
     getConfigMock.mockReturnValue(baseConfig);
-    getRendererConfigMock.mockReturnValue({ hasRealtimeApiKey: true });
-    setAudioDevicePreferencesMock.mockResolvedValue({ hasRealtimeApiKey: true });
-    setSecretMock.mockResolvedValue({ hasRealtimeApiKey: true });
+    getRendererConfigMock.mockReturnValue({ hasRealtimeApiKey: true, hasMeshyApiKey: true });
+    setAudioDevicePreferencesMock.mockResolvedValue({ hasRealtimeApiKey: true, hasMeshyApiKey: true });
+    setSecretMock.mockResolvedValue({ hasRealtimeApiKey: true, hasMeshyApiKey: true });
     testSecretMock.mockResolvedValue({ ok: true });
 
     await import('../src/main.js');
@@ -1002,6 +1007,7 @@ describe('main process bootstrap', () => {
 
     const config = {
       realtimeApiKey: 'rt-key',
+      meshyApiKey: 'meshy-key',
       audioInputDeviceId: undefined,
       audioOutputDeviceId: undefined,
       featureFlags: {},
@@ -1025,7 +1031,7 @@ describe('main process bootstrap', () => {
 
     loadMock.mockResolvedValue(config);
     getConfigMock.mockReturnValue(config);
-    getRendererConfigMock.mockReturnValue({ hasRealtimeApiKey: true });
+    getRendererConfigMock.mockReturnValue({ hasRealtimeApiKey: true, hasMeshyApiKey: true });
 
     await import('../src/main.js');
 

--- a/app/main/tests/preload.test.ts
+++ b/app/main/tests/preload.test.ts
@@ -146,6 +146,24 @@ describe('preload bridge', () => {
     invoke.mockResolvedValueOnce(true);
     await api.avatar?.triggerBehaviorCue('greet_face');
     expect(invoke).toHaveBeenCalledWith('avatar:trigger-behavior', 'greet_face');
+
+    invoke.mockResolvedValueOnce({ jobId: 'job-1' });
+    await expect(api.avatar?.generateMeshyModel({ prompt: 'A friendly assistant' })).resolves.toEqual({
+      jobId: 'job-1',
+    });
+    expect(invoke).toHaveBeenCalledWith('avatar:meshy-generate', { prompt: 'A friendly assistant' });
+
+    invoke.mockResolvedValueOnce({ jobId: 'job-1', status: 'queued' });
+    await expect(api.avatar?.getMeshyStatus('job-1')).resolves.toEqual({ jobId: 'job-1', status: 'queued' });
+    expect(invoke).toHaveBeenCalledWith('avatar:meshy-status', 'job-1');
+
+    invoke.mockResolvedValueOnce({ vrmId: 'vrm-99' });
+    await expect(api.avatar?.acceptMeshyModel('job-1')).resolves.toEqual({ vrmId: 'vrm-99' });
+    expect(invoke).toHaveBeenCalledWith('avatar:meshy-accept', 'job-1');
+
+    invoke.mockResolvedValueOnce(true);
+    await api.avatar?.rejectMeshyModel('job-1');
+    expect(invoke).toHaveBeenCalledWith('avatar:meshy-reject', 'job-1');
   });
 
   it('exposes avatar animation helpers through the bridge', async () => {

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -60,7 +60,7 @@ interface TranscriptEntry {
 
 type SecretKeyState<T> = Record<ConfigSecretKey, T>;
 
-const SECRET_KEYS: ConfigSecretKey[] = ['realtimeApiKey', 'wakeWordAccessKey'];
+const SECRET_KEYS: ConfigSecretKey[] = ['realtimeApiKey', 'wakeWordAccessKey', 'meshyApiKey'];
 const REQUIRED_BRIDGE_KEYS: (keyof PreloadApi)[] = ['config', 'wakeWord', 'ping'];
 
 interface SecretStatusState {
@@ -81,6 +81,11 @@ const SECRET_METADATA: Record<
     label: 'Porcupine access key',
     description: 'Authorizes on-device wake word detection.',
     isConfigured: (config) => Boolean(config?.wakeWord?.hasAccessKey),
+  },
+  meshyApiKey: {
+    label: 'Meshy API key',
+    description: 'Enables Meshy avatar generation workflows.',
+    isConfigured: (config) => Boolean(config?.hasMeshyApiKey),
   },
 };
 
@@ -620,18 +625,22 @@ export default function App() {
   const [secretInputs, setSecretInputs] = useState<SecretKeyState<string>>(() => ({
     realtimeApiKey: '',
     wakeWordAccessKey: '',
+    meshyApiKey: '',
   }));
   const [secretStatus, setSecretStatus] = useState<SecretKeyState<SecretStatusState>>(() => ({
     realtimeApiKey: { status: 'idle', message: null },
     wakeWordAccessKey: { status: 'idle', message: null },
+    meshyApiKey: { status: 'idle', message: null },
   }));
   const [secretSaving, setSecretSaving] = useState<SecretKeyState<boolean>>(() => ({
     realtimeApiKey: false,
     wakeWordAccessKey: false,
+    meshyApiKey: false,
   }));
   const [secretTesting, setSecretTesting] = useState<SecretKeyState<boolean>>(() => ({
     realtimeApiKey: false,
     wakeWordAccessKey: false,
+    meshyApiKey: false,
   }));
   const [realtimeToken, setRealtimeToken] = useState<string | null>(null);
   const [realtimeTokenError, setRealtimeTokenError] = useState<string | null>(null);

--- a/app/renderer/src/avatar/types.ts
+++ b/app/renderer/src/avatar/types.ts
@@ -65,6 +65,29 @@ export interface AvatarPoseUploadResult {
   pose: AvatarPoseSummary;
 }
 
+export type MeshyJobStatus = 'queued' | 'generating' | 'rigging' | 'completed' | 'failed';
+
+export interface MeshyModelGenerationRequest {
+  prompt: string;
+}
+
+export interface MeshyModelGenerationResult {
+  jobId: string;
+}
+
+export interface MeshyModelStatus {
+  jobId: string;
+  status: MeshyJobStatus;
+  progress?: number;
+  previewPath?: string | null;
+  fbxPath?: string | null;
+  errorMessage?: string | null;
+}
+
+export interface MeshyModelAcceptanceResult {
+  vrmId: string;
+}
+
 /** Request to evaluate a pose against its original prompt using vision LLM */
 export interface PoseEvaluationRequest {
   poseId: string;
@@ -108,4 +131,8 @@ export interface AvatarBridge {
   loadPose(poseId: string): Promise<unknown>;
   evaluatePose(request: PoseEvaluationRequest): Promise<PoseEvaluationResult>;
   refinePose(request: PoseEvaluationRequest): Promise<AvatarPoseUploadResult>;
+  generateMeshyModel(request: MeshyModelGenerationRequest): Promise<MeshyModelGenerationResult>;
+  getMeshyStatus(jobId: string): Promise<MeshyModelStatus>;
+  acceptMeshyModel(jobId: string): Promise<MeshyModelAcceptanceResult>;
+  rejectMeshyModel(jobId: string): Promise<void>;
 }

--- a/app/renderer/tests/App.test.tsx
+++ b/app/renderer/tests/App.test.tsx
@@ -197,6 +197,10 @@ function createAvatarBridgeMock(overrides: Partial<AvatarBridge> = {}): AvatarBr
         fileSha: 'sha',
       },
     }),
+    generateMeshyModel: vi.fn().mockResolvedValue({ jobId: 'meshy-job-1' }),
+    getMeshyStatus: vi.fn().mockResolvedValue({ jobId: 'meshy-job-1', status: 'queued' }),
+    acceptMeshyModel: vi.fn().mockResolvedValue({ vrmId: 'meshy-vrm-1' }),
+    rejectMeshyModel: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -242,6 +246,7 @@ describe('App component', () => {
       audioOutputDeviceId: '',
       featureFlags: { transcriptOverlay: true },
       hasRealtimeApiKey: true,
+      hasMeshyApiKey: false,
       realtimeVoice: 'shimmer',
       metrics: {
         enabled: false,
@@ -627,6 +632,7 @@ describe('App component', () => {
           audioOutputDeviceId: '',
           featureFlags: { transcriptOverlay: true },
           hasRealtimeApiKey: true,
+          hasMeshyApiKey: false,
           wakeWord: {
             keywordPath: '',
             keywordLabel: '',
@@ -707,6 +713,14 @@ describe('App component', () => {
       expect(within(realtimeCard).getByText(/Status: Configured/i)).toBeInTheDocument();
     }
 
+    const meshyCard = screen
+      .getByRole('heading', { name: /Meshy API key/i })
+      .closest('article');
+    expect(meshyCard).not.toBeNull();
+    if (meshyCard) {
+      expect(within(meshyCard).getByText(/Status: Not configured/i)).toBeInTheDocument();
+    }
+
     await openTab(/ChatGPT/i);
 
     expect(await screen.findByText(/Speech gate:/i)).toBeInTheDocument();
@@ -730,6 +744,7 @@ describe('App component', () => {
           audioOutputDeviceId: '',
           featureFlags: { transcriptOverlay: true },
           hasRealtimeApiKey: true,
+          hasMeshyApiKey: false,
           wakeWord: {
             keywordPath: '',
             keywordLabel: '',
@@ -921,6 +936,7 @@ describe('App component', () => {
           audioOutputDeviceId: '',
           featureFlags: { transcriptOverlay: true },
           hasRealtimeApiKey: true,
+          hasMeshyApiKey: false,
           wakeWord: {
             keywordPath: '',
             keywordLabel: '',
@@ -1053,6 +1069,7 @@ describe('App component', () => {
           audioOutputDeviceId: '',
           featureFlags: {},
           hasRealtimeApiKey: true,
+          hasMeshyApiKey: false,
           wakeWord: {
             keywordPath: '',
             keywordLabel: '',
@@ -1083,6 +1100,7 @@ describe('App component', () => {
       audioOutputDeviceId: '',
       featureFlags: {},
       hasRealtimeApiKey: true,
+      hasMeshyApiKey: false,
       realtime: { mintEphemeralToken: mintEphemeralTokenMock },
       wakeWord: {
         keywordPath: '',
@@ -1191,6 +1209,7 @@ describe('App component', () => {
           audioOutputDeviceId: '',
           featureFlags: {},
           hasRealtimeApiKey: true,
+          hasMeshyApiKey: false,
           wakeWord: {
             keywordPath: '',
             keywordLabel: '',
@@ -1251,6 +1270,7 @@ describe('App component', () => {
           audioOutputDeviceId: '',
           featureFlags: {},
           hasRealtimeApiKey: true,
+          hasMeshyApiKey: false,
           realtimeVoice: 'shimmer',
           sessionInstructions: 'Persisted instructions from config',
           wakeWord: {
@@ -1335,6 +1355,7 @@ describe('App component', () => {
           audioOutputDeviceId: '',
           featureFlags: {},
           hasRealtimeApiKey: true,
+          hasMeshyApiKey: false,
           realtimeVoice: 'verse',
           wakeWord: {
             keywordPath: '',

--- a/app/renderer/tests/avatar/avatar-configurator.test.tsx
+++ b/app/renderer/tests/avatar/avatar-configurator.test.tsx
@@ -129,6 +129,10 @@ function createAvatarBridgeStub(overrides: Partial<AvatarBridge> = {}): AvatarBr
         fileSha: 'sha',
       },
     }),
+    generateMeshyModel: vi.fn().mockResolvedValue({ jobId: 'meshy-job-1' }),
+    getMeshyStatus: vi.fn().mockResolvedValue({ jobId: 'meshy-job-1', status: 'queued' }),
+    acceptMeshyModel: vi.fn().mockResolvedValue({ vrmId: 'meshy-vrm-1' }),
+    rejectMeshyModel: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }


### PR DESCRIPTION
### Motivation

- Implement the first two steps of the Meshy step-by-step plan by confirming scope against the PRD/archspec/plan and adding the required data contracts. 
- Persist a Meshy API key alongside existing secrets so the main process can orchestrate Meshy operations securely. 
- Surface Meshy generation/status/accept/reject operations through the preload IPC bridge so the renderer can initiate and monitor avatar generation. 
- Update tests and documentation to record progress and keep interfaces typed and covered.

### Description

- Added `meshyApiKey` to `AppConfig` and `RendererConfig`, added env/secret resolution + persist/test stubs in `ConfigManager`, and extended `ConfigSecretKey` to include `meshyApiKey`. 
- Introduced Meshy data types and IPC contracts (`generateMeshyModel`, `getMeshyStatus`, `acceptMeshyModel`, `rejectMeshyModel`) in `avatar/types.ts`, the preload bridge (`app/main/src/preload.ts`), and renderer avatar types. 
- Exposed Meshy secret UI state/metadata in the renderer (`app/renderer/src/App.tsx`) and added corresponding test mocks and assertions across renderer and main tests. 
- Updated `AGENTS.md` to record completion of Meshy plan steps 1-2 and adjusted unit test fixtures to include Meshy mocks.

### Testing

- Ran `pnpm install` successfully to ensure workspace dependencies resolved. 
- Ran `pnpm lint` which completed successfully across packages. 
- Ran `pnpm typecheck` which completed successfully after updating types and test stubs. 
- Ran `pnpm test` and `pnpm test:coverage` but both failed in this environment due to the Electron executable not being available (spawn ENOENT), preventing full CI test execution for Electron-dependent suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e1e0ce14c8330b43bd77060c0b968)