### PR TITLE
Add Meshy client unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,3 +143,4 @@ Refer to `plan.md`, `archspec.md`, and `prd.md` for the authoritative product an
 - 2025-03-08 — Appended a step-by-step build plan to `meshy-plan.md`.
 - 2025-03-09 — Completed Meshy plan steps 1-2 by confirming scope against `prd.md`/`archspec.md`/`plan.md` and defining Meshy config + IPC data contracts.
 - 2025-03-10 — Installed Electron runtime dependencies for Ubuntu 24.04 to unblock test execution in root CI environments.
+- 2025-03-11 — Added Meshy client unit tests to cover job creation, status normalization, and asset downloads.

--- a/app/main/tests/meshy-client.test.ts
+++ b/app/main/tests/meshy-client.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+import { MeshyClient } from '../src/avatar/meshy-client.js';
+
+const createJsonResponse = (body: unknown, status = 200): Response => {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+const createBufferResponse = (buffer: Buffer, status = 200): Response => {
+  return new Response(buffer, {
+    status,
+    headers: { 'Content-Type': 'application/octet-stream' },
+  });
+};
+
+describe('MeshyClient', () => {
+  it('requires a non-empty API key', () => {
+    expect(() => new MeshyClient({ apiKey: '' })).toThrow('Meshy API key is required.');
+    expect(() => new MeshyClient({ apiKey: '  ' })).toThrow('Meshy API key is required.');
+  });
+
+  it('creates a Meshy generation job with the expected payload', async () => {
+    const fetcher = vi.fn().mockResolvedValue(createJsonResponse({ id: 'job-123' }));
+    const client = new MeshyClient({ apiKey: 'meshy-key', fetcher });
+
+    const result = await client.createGenerationJob({ prompt: '  Friendly assistant  ' });
+
+    expect(result).toEqual({ jobId: 'job-123' });
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://api.meshy.ai/v1/text-to-3d',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          prompt: 'Friendly assistant',
+          model_format: 'fbx',
+          rig: true,
+        }),
+        headers: expect.objectContaining({
+          Authorization: 'Bearer meshy-key',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+
+  it('normalizes Meshy status responses', async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        state: 'running',
+        progress: 0.45,
+        outputs: {
+          preview: 'https://preview.example',
+          fbx: 'https://asset.example/model.fbx',
+        },
+      }),
+    );
+    const client = new MeshyClient({ apiKey: 'meshy-key', fetcher });
+
+    const result = await client.getJobStatus('job-9');
+
+    expect(result).toEqual({
+      jobId: 'job-9',
+      status: 'generating',
+      progress: 45,
+      previewPath: 'https://preview.example',
+      fbxPath: 'https://asset.example/model.fbx',
+      errorMessage: null,
+    });
+  });
+
+  it('downloads assets and persists them to disk', async () => {
+    const buffer = Buffer.from('fbx-data');
+    const fetcher = vi.fn().mockResolvedValue(createBufferResponse(buffer));
+    const client = new MeshyClient({ apiKey: 'meshy-key', fetcher });
+    const directory = await mkdtemp(path.join(tmpdir(), 'meshy-client-'));
+    const destination = path.join(directory, 'model.fbx');
+
+    const result = await client.downloadAsset('https://asset.example/model.fbx', destination);
+
+    expect(result).toEqual({ bytes: buffer.length });
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://asset.example/model.fbx',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer meshy-key',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+    await expect(readFile(destination)).resolves.toEqual(buffer);
+    await rm(directory, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
### Motivation
- Validate the Meshy client behavior described in `meshy-plan.md` by adding unit tests for job creation, status parsing, and asset download handling. 
- Ensure the main-process Meshy integration has deterministic behavior for downstream job orchestration and conversion steps. 
- Provide a safety net for future refactors of the Meshy client and IPC wiring by covering common edge cases. 

### Description
- Added `app/main/tests/meshy-client.test.ts` with unit tests that assert job creation payloads, status normalization, and `downloadAsset` file persistence using a mocked `fetcher`.
- Tests mock JSON and binary `Response` objects and write downloaded assets to a temporary directory to verify `persistFile` behavior.
- Updated `AGENTS.md` to record the addition of Meshy client tests and the rollout date.

### Testing
- Ran `pnpm lint` and it completed successfully. 
- Ran `pnpm typecheck` and it completed successfully. 
- Ran `pnpm test` and the run failed due to a renderer/electron spawn error (`spawn ENOENT`) which prevented the full suite from completing. 
- Ran `pnpm test:coverage` and it failed for the same `spawn ENOENT` Electron executable issue, preventing coverage collection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69601f2b5fc08330988ae7cb1e1fc4ea)